### PR TITLE
Path cleanup and mvn compatibility

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -58,9 +58,9 @@ if exist "%_ANT_HOME%\tools\ant.jar" (
 
 set _CLASSPATH=%_CLASSPATH%;%_ANT_JARS%
 
-set _XALAN_BUILD_CLASSPATH=..\xalan-java\build\*:..\build\*
-set _XERCES_ENDORSED_CLASSPATH=..\xalan-java\lib:..\lib:..\xalan-java\lib\endorsed:..\lib\endorsed
-set _XERCES_IMPL_CLASSPATH=..\xalan-java\lib\*:..\lib\*:..\xalan-java\lib\endorsed\*:..\lib\endorsed\*
+set _XALAN_BUILD_CLASSPATH=..\xalan-java\build\*;..\build\*
+set _XERCES_ENDORSED_CLASSPATH=..\xalan-java\lib;..\lib;..\xalan-java\lib\endorsed;..\lib\endorsed
+set _XERCES_IMPL_CLASSPATH=..\xalan-java\lib\*;..\lib\*;..\xalan-java\lib\endorsed\*;..\lib\endorsed\*
 
 : Override JRE defaults to set our own, preferring the "real" Apache code
 : to the shadowed version that ships with the JRE.

--- a/build.bat
+++ b/build.bat
@@ -20,6 +20,7 @@ rem     Name:   build.bat
 rem     Author: shane_curcuru@lotus.com,
 rem             ggregory@apache.org,
 rem             mukulg@apache.org
+rem             jkesselm@apache.org
 rem                
 rem     See:    build.xml
 rem
@@ -41,7 +42,7 @@ if exist "%JAVA_HOME%\lib\tools.jar" (
 set _JAVACMD=%JAVA_HOME%\bin\java
 
 rem On windows grab all arguments at once
-set ANT_CMD_LINE_ARGS=%*
+set _ANT_CMD_LINE_ARGS=%*
 
 rem Default ANT_HOME to the one what user has set
 if not "%ANT_HOME%"=="" set _ANT_HOME=%ANT_HOME%
@@ -57,12 +58,22 @@ if exist "%_ANT_HOME%\tools\ant.jar" (
 
 set _CLASSPATH=%_CLASSPATH%;%_ANT_JARS%
 
-set XALAN_BUILD_DIR_PATH=..\xalan-java\build;..\build
+set _XALAN_BUILD_CLASSPATH=../xalan-java/build/*:../build/*
+set _XERCES_ENDORSED_CLASSPATH=../xalan-java/lib:../lib:../xalan-java/lib/endorsed:../lib/endorsed
+set _XERCES_IMPL_CLASSPATH=../xalan-java/lib/*:../lib/*:../xalan-java/lib/endorsed/*:../lib/endorsed/*
 
-set XERCES_ENDORSED_DIR_PATH=..\xalan-java\lib\endorsed;..\lib\endorsed
+: Override JRE defaults to set our own, preferring the "real" Apache code
+: to the shadowed version that ships with the JRE.
+set _JAXP_USE_APACHE="-Djavax.xml.transform.TransformerFactory=org.apache.xalan.processor.TransformerFactoryImpl -Djavax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl -Djavax.xml.parsers.SAXParserFactory=org.apache.xerces.jaxp.SAXParserFactoryImpl"
+
+: Endorsed should no longer be necessary, given JAXP/TrAX overrides above.
+: Just make sure they're on the classpaths.
+: set _USE_OLD_ENDORSED_DIRS=-Djava.endorsed.dirs=%_XALAN_BUILD_CLASSPATH%;%_XERCES_ENDORSED_CLASSPATH%
+set _USE_OLD_ENDORSED_DIRS=
+set _CLASSPATH=%_XALAN_BUILD_CLASSPATH%;%_XERCES_IMPL_CLASSPATH%;%_CLASSPATH%
 
 @echo on
-"%_JAVACMD%" -mx1024m -Djava.endorsed.dirs=%XALAN_BUILD_DIR_PATH%;%XERCES_ENDORSED_DIR_PATH% -classpath "%_CLASSPATH%" org.apache.tools.ant.Main %ANT_CMD_LINE_ARGS%
+"%_JAVACMD%" -mx1024m %_USE_OLD_ENDORSED_DIRS% -classpath "%_CLASSPATH%" org.apache.tools.ant.Main %_ANT_CMD_LINE_ARGS%
 @echo off
 
 goto end
@@ -73,5 +84,11 @@ echo Warning: JAVA_HOME environment variable is not set
 :end
 set _CLASSPATH=
 set _ANT_HOME=
+set _ANT_CMD_LINE_ARGS=
 set _JAVACMD=
 set _ANT_JARS=
+set _XALAN_BUILD_CLASSPATH=
+set _XERCES_ENDORSED_CLASSPATH=
+set _XERCES_IMPL_CLASSPATH=
+set _JAXP_USE_APACHE=
+set _USE_OLD_ENDORSED_DIRS=

--- a/build.bat
+++ b/build.bat
@@ -58,9 +58,9 @@ if exist "%_ANT_HOME%\tools\ant.jar" (
 
 set _CLASSPATH=%_CLASSPATH%;%_ANT_JARS%
 
-set _XALAN_BUILD_CLASSPATH=../xalan-java/build/*:../build/*
-set _XERCES_ENDORSED_CLASSPATH=../xalan-java/lib:../lib:../xalan-java/lib/endorsed:../lib/endorsed
-set _XERCES_IMPL_CLASSPATH=../xalan-java/lib/*:../lib/*:../xalan-java/lib/endorsed/*:../lib/endorsed/*
+set _XALAN_BUILD_CLASSPATH=..\xalan-java\build\*:..\build\*
+set _XERCES_ENDORSED_CLASSPATH=..\xalan-java\lib:..\lib:..\xalan-java\lib\endorsed:..\lib\endorsed
+set _XERCES_IMPL_CLASSPATH=..\xalan-java\lib\*:..\lib\*:..\xalan-java\lib\endorsed\*:..\lib\endorsed\*
 
 : Override JRE defaults to set our own, preferring the "real" Apache code
 : to the shadowed version that ships with the JRE.

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@
 #		Fresh port from Mukul Gandhi's revised build.bat.
 #		WARNING: This currently does not include the hooks needed
 #		to make the script compatable with cygwin (unix/Linux shell
-#		and commands ported to run under Windows). See 
+#		and commands ported to run under Windows). See
 #		deprecated_build.sh to see how we handled the cygwin
 #		syntax differences back in 2001. These days, Windows users
 #		are more likely to use WSL, which simplifies matters.
@@ -39,7 +39,7 @@ echo
 echo Xalan-J test automation build
 echo -----------------------------
 
-if [ "$1" = "-h" ]; then 
+if [ "$1" = "-h" ]; then
     echo build.sh - executes Xalan Java-based test automation
     echo   Usage:   build [target] [-D options]
     echo   Example: build api -DtestClass=TransformerAPITest -Dqetest.loggingLevel=30
@@ -50,19 +50,19 @@ if [ "$1" = "-h" ]; then
     exit 1
 fi
 
-if [ "$JAVA_HOME" = "" ]; then 
+if [ "$JAVA_HOME" = "" ]; then
     echo Warning: JAVA_HOME environment variable is not exported
     echo You may have meant to set it to /etc/alternatives/java_sdk
     exit 1
 fi
 
 JAVACMD=$JAVA_HOME/bin/java
-    
+
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
 
 # Default is to use a copy of ant bundled with xalan-java
-if [ $ANT_HOME = "" ]; then
-   _ANT_HOME=../xalan-java   
+if [ "$ANT_HOME" = "" ]; then
+   _ANT_HOME=../xalan-java
 else
    _ANT_HOME=$ANT_HOME
 fi
@@ -98,7 +98,7 @@ CLASSPATH=$XALAN_BUILD_CLASSPATH:$XERCES_IMPL_CLASSPATH:$CLASSPATH
 
 # Reminder: Note $* versus $@ distinction
 # Also note classpath must be quoted to prevent CLI expansion of *
-echo Running: $JAVACMD -mx1024m $USE_OLD_ENDORSED_DIRS -classpath "$CLASSPATH" $JAXP_USE_APACHE org.apache.tools.ant.Main "$@"
-$JAVACMD -mx1024m $USE_OLD_ENDORSED_DIRS -classpath "$CLASSPATH" $JAXP_USE_APACHE org.apache.tools.ant.Main "$@"
+echo Running: "$JAVACMD" -mx1024m $USE_OLD_ENDORSED_DIRS -classpath "$CLASSPATH" $JAXP_USE_APACHE org.apache.tools.ant.Main "$@"
+"$JAVACMD" -mx1024m $USE_OLD_ENDORSED_DIRS -classpath "$CLASSPATH" $JAXP_USE_APACHE org.apache.tools.ant.Main "$@"
 
 echo "build.sh complete!"

--- a/build.xml
+++ b/build.xml
@@ -53,11 +53,32 @@ dependencies - users must manually 'build jar' first.
     <!-- Then, read in the default checked-in properties -->
     <property file="test.properties" />
 
+    <!-- If not otherwise set, use the Apache-native JAXP/TrAX
+         FactoryImpl classes, overriding any compiled-in or
+         environmental defaults, defaulting to interpretive Xalan as
+         in the past (This is to prevent defaulting to
+         com.sun.org.apache.local.*, as recent JREs tend to, without
+         having to play games with endorsed or bootclasspath to get
+         our Factories to be found first.  If you want to run the
+         tests with their default being the compiler and processor
+         shipped with the JRE, or any other, set these in the
+         properties file. To run against the JRE's defaults,
+         you can set these explicitly or preset JAXP.set.impl
+         to value="".
+    -->
+    <property name="TransformerFactoryImpl" value="org.apache.xalan.processor.TransformerFactoryImpl"/>
+    <property name="DocumentBuilderFactoryImpl" value="org.apache.xerces.jaxp.DocumentBuilderFactoryImpl"/>
+    <property name="SAXParserFactoryImpl" value="org.apache.xerces.jaxp.SAXParserFactoryImpl"/>
+    <property name="JAXP.set.Transformer" value="-Djavax.xml.transform.TransformerFactory=${TransformerFactoryImpl}"/>
+    <property name="JAXP.set.DocumentBuilder" value="-Djavax.xml.parsers.DocumentBuilderFactory=${DocumentBuilderFactoryImpl}"/>
+    <property name="JAXP.set.SAXParser" value="-Djavax.xml.parsers.SAXParserFactory=${SAXParserFactoryImpl}"/>
+    <echo message="Initial JAXP/TrAX configuration: ${JAXP.set.Transformer} ${JAXP.set.DocumentBuilder} ${JAXP.set.SAXParser}"/>
+
     <property name="smoketest.conf.excludes" value="${smoketest.conf.normal.excludes};${smoketest.conf.supplemental.excludes}"/>
     <property name="smoketest.xsltc.conf.excludes" value="${smoketest.xsltc.conf.normal.excludes};${smoketest.xsltc.conf.supplemental.excludes}"/>
     <!-- Also provide environment properties with a special prefix which 
          allows us to detect if JARDIR is set.
-   -->
+    -->
     <property environment="ENV" />
 
     <property name="year" value="2000-2023"/>
@@ -89,7 +110,7 @@ dependencies - users must manually 'build jar' first.
     <property name="qetest.jar.name" value="qetest.jar"/>
     <property name="testxsl.jar" value="${test.build.dir}/${testxsl.jar.name}"/>
     <property name="qetest.jar" value="${test.build.dir}/${qetest.jar.name}"/>
-	
+    
     <!-- Specific locations related to Xalan code, which should be in a sister tree to us -->
     <property name="xalan.relpath" value="../xalan-java"/>    
     <property name="xalan.lib.dir" value="${xalan.relpath}/lib"/>  
@@ -98,14 +119,21 @@ dependencies - users must manually 'build jar' first.
     <property name="xalan.xdocs.dir" value="${xalan.relpath}/xdocs"/>
     <property name="xalan.generator.styletargz" value="${xalan.xdocs.dir}/xml-site-style.tar.gz"/>
 
-    <!-- Various names/locations of dependent jars -->
+    <!-- Various names/locations of dependent jars.  We need a better
+         way to handle jarfiles with version numbers; Ant doesn't seem
+         to have a way to resolve wildcards. Of course we're hoping to
+         phase Ant out...
+         For now, just have both on the paths.
+    -->
     <property name="xalan.jar" value="${xalan.build.dir}/xalan.jar"/>
-    <property name="xalan.unbundled.jar" 
-              value="${xalan.build.dir}/xalan-unbundled.jar"/>
-    <property name="xsltc.jar" value="${xalan.build.dir}/xsltc.jar"/>
     <property name="ser.jar" value="${xalan.build.dir}/serializer.jar"/>
-    <property name="xml-apis.jar" value="${xalan.lib.dir}/xml-apis.jar"/>
-    <property name="parserjar" value="${xalan.lib.dir}/xercesImpl.jar"/>
+    <property name="endorsed.xml-apis.jar" value="${xalan.lib.dir}/endorsed/xml-apis.jar"/>
+    <property name="endorsed.parserjar" value="${xalan.lib.dir}/endorsed/xercesImpl.jar"/>
+    <property name="xml-apis.jar" value="${xalan.lib.dir}/xml-apis-1.4.01.jar"/>
+    <property name="parserjar" value="${xalan.lib.dir}/xercesImpl-2.12.2.jar"/>
+    <!-- <property name="xalan.unbundled.jar"  -->
+    <!--           value="${xalan.build.dir}/xalan-unbundled.jar"/> -->
+    <!-- <property name="xsltc.jar" value="${xalan.build.dir}/xsltc.jar"/> -->
 
     <!-- JTidy is used by the XSLTC comparator -->
     <!--<property name="jtidy.jar" value="${test.tools.dir}/Tidy.jar"/>-->
@@ -132,13 +160,15 @@ dependencies - users must manually 'build jar' first.
     <property name="test.xdocs.style" value="${test.xdocs.dir}/style"/>
     <property name="doc.generator" value="org.apache.stylebook.StyleBook"/>
     <path id="test.docs.class.path">
-        <pathelement location="${stylebook.jar}" />
-        <pathelement location="${doclet.jar}" />
-        <pathelement location="${jtidy.jar}" />
-        <pathelement location="${xalan.jar}" />
-        <pathelement location="${ser.jar}" />
-        <pathelement location="${xml-apis.jar}" />
-        <pathelement location="${parserjar}" />
+      <pathelement location="${stylebook.jar}" />
+      <pathelement location="${doclet.jar}" />
+      <pathelement location="${jtidy.jar}" />
+      <pathelement location="${xalan.jar}" />
+      <pathelement location="${ser.jar}" />
+      <pathelement location="${endorsed.xml-apis.jar}" />
+      <pathelement location="${endorsed.parserjar}" />
+      <pathelement location="${xml-apis.jar}" />
+      <pathelement location="${parserjar}" />
     </path>
 
     <!-- Note: given that many of the tests interact with xerces and 
@@ -160,1397 +190,1412 @@ dependencies - users must manually 'build jar' first.
     <!-- ================================================================== -->
     <!-- Classpath used when compiling tests -->
     <path id="compiletest.class.path">
-        <pathelement location="${xalan.jar}" />
-        <pathelement location="${xsltc.jar}" />  <!-- add this so we can test the
-                                                      separate jar distribution -->
-        <pathelement location="${ser.jar}" />
-        <pathelement location="${xml-apis.jar}" />
-        <pathelement location="${parserjar}" />
-        <pathelement location="${jtidy.jar}" />
+      <pathelement location="${xalan.jar}" />
+      <!-- separate xsltc.jar is no longer produced -->
+      <!-- <pathelement location="${xsltc.jar}" /> -->
+      <pathelement location="${ser.jar}" />
+      <pathelement location="${endorsed.xml-apis.jar}" />
+      <pathelement location="${xml-apis.jar}" />
+      <pathelement location="${endorsed.parserjar}" />
+      <pathelement location="${parserjar}" />
+      <pathelement location="${jtidy.jar}" />
     </path>
 
     <!-- Classpath used when running API tests -->
     <path id="api.class.path">
-        <pathelement location="${xalan.jar}" />
-        <pathelement location="${ser.jar}" />
-        <pathelement location="${xml-apis.jar}" />
-        <pathelement location="${parserjar}" />
-        <pathelement location="${testxsl.jar}" />
-        <pathelement location="${jtidy.jar}" />
+      <pathelement location="${xalan.jar}" />
+      <pathelement location="${ser.jar}" />
+      <pathelement location="${endorsed.xml-apis.jar}" />
+      <pathelement location="${xml-apis.jar}" />
+      <pathelement location="${endorsed.parserjar}" />
+      <pathelement location="${parserjar}" />
+      <pathelement location="${testxsl.jar}" />
+      <pathelement location="${jtidy.jar}" />
     </path>
     
     <path id="testxsl.class.path">
-       <pathelement location="${testxsl.jar}" />
+      <pathelement location="${testxsl.jar}" />
     </path>
 
     <!-- Classpath used when running conf or conformance tests -->
     <path id="conf.class.path">
-        <pathelement location="${xalan.jar}" />
-        <pathelement location="${ser.jar}" />
-        <pathelement location="${xml-apis.jar}" />
-        <pathelement location="${parserjar}" />
-        <pathelement location="${testxsl.jar}" />
-        <pathelement location="${jtidy.jar}" />
-    </path>
+      <pathelement location="${xalan.jar}" />
+      <pathelement location="${ser.jar}" />
+      <pathelement location="${endorsed.xml-apis.jar}" />
+      <pathelement location="${xml-apis.jar}" />
+      <pathelement location="${endorsed.parserjar}" />
+      <pathelement location="${parserjar}" />
+      <pathelement location="${testxsl.jar}" />
+      <pathelement location="${jtidy.jar}" />
+</path>
 
-    <!-- Boot class path for JDK 1.4+ -->
-    <path id="boot.class.path">                                  
-        <pathelement location="${xml-apis.jar}" />
-        <pathelement location="${parserjar}" />
-        <pathelement location="${ser.jar}" />
-        <pathelement location="${xalan.jar}" />
-        <!--<pathelement location="${xsltc.jar}" />-->  <!-- add this so we can test the
-                                                              separate jar distribution -->        
-        <pathelement path="${sun.boot.class.path}" />
-    </path>
+<!-- Boot class path for JDK 1.4+ -->
+<path id="boot.class.path">                                  
+  <pathelement location="${endorsed.xml-apis.jar}" />
+  <pathelement location="${xml-apis.jar}" />
+  <pathelement location="${endorsed.parserjar}" />
+  <pathelement location="${parserjar}" />
+  <pathelement location="${ser.jar}" />
+  <pathelement location="${xalan.jar}" />
+  <!-- separate xsltc.jar is no longer produced -->
+  <!-- <pathelement location="${xsltc.jar}" /> -->
+  <pathelement path="${sun.boot.class.path}" />
+</path>
 
-    <!-- Gump build xml-xalan2-smoketest should use xalan.unbundled.jar -->
-    <path id="boot.class.path.gump">
-        <pathelement location="${sun.boot.class.path}" />
-    </path>
-    
-    <!-- Classpath used when running perf or performance tests -->
-    <path id="perf.class.path">
-        <path refid="conf.class.path" />
-    </path>
+<!-- Gump build xml-xalan2-smoketest should use xalan.unbundled.jar -->
+<path id="boot.class.path.gump">
+  <pathelement location="${sun.boot.class.path}" />
+</path>
 
-    <!-- Classpath used when running EXSLT tests -->
-    <path id="exslt.class.path">
-        <path refid="conf.class.path" />
-    </path>
+<!-- Classpath used when running perf or performance tests -->
+<path id="perf.class.path">
+  <path refid="conf.class.path" />
+</path>
 
-    <!-- Classpath used when running contrib or user-contributed tests -->
-    <path id="contrib.class.path">
-        <path refid="conf.class.path" />
-    </path>
+<!-- Classpath used when running EXSLT tests -->
+<path id="exslt.class.path">
+  <path refid="conf.class.path" />
+</path>
 
-    <!-- Classpath used when running Bugzilla tests -->
-    <path id="bugzilla.class.path">
-        <path refid="api.class.path" />
-        <pathelement location="${tests.bugzilla.build.dir}" />
-    </path>
+<!-- Classpath used when running contrib or user-contributed tests -->
+<path id="contrib.class.path">
+  <path refid="conf.class.path" />
+</path>
 
-    <!-- Classpath used when running Jira tests -->
-    <path id="jira.class.path">
-        <path refid="api.class.path" />
-        <pathelement location="${tests.jira.build.dir}" />
-    </path>
+<!-- Classpath used when running Bugzilla tests -->
+<path id="bugzilla.class.path">
+  <path refid="api.class.path" />
+  <pathelement location="${tests.bugzilla.build.dir}" />
+</path>
 
-    <!-- Classpath used when running extensions tests -->
-    <path id="extensions.class.path">
-        <pathelement location="${xalan.jar}" />         
-        <path refid="testxsl.class.path" />
-        <pathelement location="${commons-logging.jar}" />
-        <pathelement location="${bsf.jar}" />        
-        <pathelement location="${js.jar}" />
-        <pathelement location="${jtidy.jar}" />
-        <pathelement location="${tests.extensions.build.dir}" />
-        <pathelement location="${tests.bugzilla.build.dir}" />        
-        <pathelement location="${tests.jira.build.dir}" />        
-        <!-- Add more pathelements if we add more Java extensions dirs -->
-    </path>
+<!-- Classpath used when running Jira tests -->
+<path id="jira.class.path">
+  <path refid="api.class.path" />
+  <pathelement location="${tests.jira.build.dir}" />
+</path>
 
-    <!-- Classpath used when build/running xslt20 XPath 2.0 RWAPI tests -->
-    <path id="rwapitest.class.path">
-        <path refid="api.class.path" />
-        <pathelement location="${xalan.build.dir}/xpathapi.jar" />
-    </path>
+<!-- Classpath used when running extensions tests -->
+<path id="extensions.class.path">
+  <pathelement location="${xalan.jar}" />         
+  <path refid="testxsl.class.path" />
+  <pathelement location="${commons-logging.jar}" />
+  <pathelement location="${bsf.jar}" />        
+  <pathelement location="${js.jar}" />
+  <pathelement location="${jtidy.jar}" />
+  <pathelement location="${tests.extensions.build.dir}" />
+  <pathelement location="${tests.bugzilla.build.dir}" />        
+  <pathelement location="${tests.jira.build.dir}" />        
+  <!-- Add more pathelements if we add more Java extensions dirs -->
+</path>
 
-    <!-- ================================================================== -->
-    <!-- Initialize: Define an Ant task that executes Xalan test automation -->
-    <!-- ================================================================== -->
-    <taskdef name="xalantest" classname="org.apache.qetest.xsl.XSLTestAntTask">
-        <classpath>
-            <!-- Needed so this build file can run: this refers to 
-                 a precompiled version of XSLTestAntTask.class that 
-                 is checked in: normally at runtime, it should come 
-                 from the testxsl.jar file instead of below.
-           -->
-            <pathelement location="${test.src.dir}" />
-            <pathelement location="${test.build.dir}" />
-            <pathelement location="${testxsl.jar}" />
-        </classpath>
-    </taskdef>
+<!-- Classpath used when build/running xslt20 XPath 2.0 RWAPI tests -->
+<path id="rwapitest.class.path">
+  <path refid="api.class.path" />
+  <pathelement location="${xalan.build.dir}/xpathapi.jar" />
+</path>
 
-    <!-- This Ant task checks, the 'api' tests pass or fail status, by inspecting 
-         content within test result XML documents -->
-    <taskdef name="apiTestsResultTask" classname="org.apache.qetest.xsl.XSLApiTestsResultTask">
-       <classpath>
-           <pathelement location="${test.src.dir}" />
-           <pathelement location="${test.build.dir}" />
-           <pathelement location="${testxsl.jar}" />
-        </classpath>
-    </taskdef>
+<!-- ================================================================== -->
+<!-- Initialize: Define an Ant task that executes Xalan test automation -->
+<!-- ================================================================== -->
+<taskdef name="xalantest" classname="org.apache.qetest.xsl.XSLTestAntTask">
+  <classpath>
+    <!-- Needed so this build file can run: this refers to 
+         a precompiled version of XSLTestAntTask.class that 
+         is checked in: normally at runtime, it should come 
+         from the testxsl.jar file instead of below.
+    -->
+    <pathelement location="${test.src.dir}" />
+    <pathelement location="${test.build.dir}" />
+    <pathelement location="${testxsl.jar}" />
+  </classpath>
+</taskdef>
 
-    <!-- This Ant task, runs XalanJ xsltc tests -->
-    <taskdef name="xsltcTestsTask" classname="org.apache.qetest.xsl.XsltcTestsTask">
-       <classpath>
-           <pathelement location="${test.src.dir}" />
-           <pathelement location="${test.build.dir}" />
-           <pathelement location="${testxsl.jar}" />
-        </classpath>
-    </taskdef>
+<!-- This Ant task checks, the 'api' tests pass or fail status, by inspecting 
+     content within test result XML documents -->
+<taskdef name="apiTestsResultTask" classname="org.apache.qetest.xsl.XSLApiTestsResultTask">
+  <classpath>
+    <pathelement location="${test.src.dir}" />
+    <pathelement location="${test.build.dir}" />
+    <pathelement location="${testxsl.jar}" />
+  </classpath>
+</taskdef>
 
-    <!-- ================================================================== -->
-    <!-- Base target for running tests with specified properties.  Actual   -->
-    <!-- work is handled by dependent tasks, at most one of which should be -->
-    <!-- executed.                                                          -->
-    <!-- ================================================================== -->
-    <target name="run.xalantest" depends="run.xalantest.default,run.xalantest.transfact"/>
+<!-- This Ant task, runs XalanJ xsltc tests -->
+<taskdef name="xsltcTestsTask" classname="org.apache.qetest.xsl.XsltcTestsTask">
+  <classpath>
+    <pathelement location="${test.src.dir}" />
+    <pathelement location="${test.build.dir}" />
+    <pathelement location="${testxsl.jar}" />
+  </classpath>
+</taskdef>
 
-    <target name="run.xalantest.default" unless="sysprop.transfact" >       
-        <antcall target="run.xalantest.default.gump"/>
-        <antcall target="run.xalantest.default.normal"/>
-    </target>
- 
-    <target name="run.xalantest.default.gump" if="gump" >
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path.gump"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" />
-    </target>
+<!-- ================================================================== -->
+<!-- Base target for running tests with specified properties.  Actual   -->
+<!-- work is handled by dependent tasks, at most one of which should be -->
+<!-- executed.                                                          -->
+<!-- ================================================================== -->
+<target name="run.xalantest" depends="run.xalantest.default,run.xalantest.transfact"/>
 
-    <target name="run.xalantest.default.normal" unless="gump" >
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" />    
-    </target>
+<target name="run.xalantest.default" unless="sysprop.transfact" >       
+  <antcall target="run.xalantest.default.gump"/>
+  <antcall target="run.xalantest.default.normal"/>
+</target>
 
-    <target name="run.xalantest.transfact" if="sysprop.transfact" >
-        <antcall target="run.xalantest.transfact.gump"/>
-        <antcall target="run.xalantest.transfact.normal"/>
-    </target>
+<target name="run.xalantest.default.gump" if="gump" >
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" />
+             <!-- bootclasspathref="boot.class.path.gump" -->
+</target>
 
-    <target name="run.xalantest.transfact.gump" if="gump">
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path.gump"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" >
-            <!-- Explicitly set TransformerFactory property to use -->
-            <sysproperty key="javax.xml.transform.TransformerFactory"
-                         value="${sysprop.transfact}" />
-        </xalantest>
-    </target>
+<target name="run.xalantest.default.normal" unless="gump" >
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" />    
+             <!-- bootclasspathref="boot.class.path" -->
+</target>
 
-    <target name="run.xalantest.transfact.normal" unless="gump">
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" >
-            <!-- Explicitly set TransformerFactory property to use -->
-            <sysproperty key="javax.xml.transform.TransformerFactory"
-                         value="${sysprop.transfact}" />
-        </xalantest>    
-    </target>
-    
-    <target name="run.xalan-extension-test" >
-        <!--<antcall target="run.xalan-extension-test.gump"/>-->
-        <antcall target="run.xalan-extension-test.normal"/>
-    </target>
+<target name="run.xalantest.transfact" if="sysprop.transfact" >
+  <antcall target="run.xalantest.transfact.gump"/>
+  <antcall target="run.xalantest.transfact.normal"/>
+</target>
 
-    <target name="run.xalan-extension-test.gump" if="gump">
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path.gump"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" >
-            <sysproperty key="org.apache.xalan.extensions.bsf.BSFManager"
-                         value="${sysprop.BSFManager}" />
-        </xalantest>
-    </target>
+<target name="run.xalantest.transfact.gump" if="gump">
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" >
+             <!-- bootclasspathref="boot.class.path.gump" -->
+    <!-- Explicitly set TransformerFactory property to use -->
+    <sysproperty key="javax.xml.transform.TransformerFactory"
+                 value="${sysprop.transfact}" />
+  </xalantest>
+</target>
 
-    <target name="run.xalan-extension-test.normal">
-        <xalantest test="${testClass}"
-            testType="${testType}"
-            classpathref="${xalantest.classpathref}"
-            bootclasspathref="boot.class.path"
-            fork="${fork-tests}"
-            failonerror="${fail-on-error}" >
-            <sysproperty key="org.apache.xalan.extensions.bsf.BSFManager"
-                         value="${sysprop.BSFManager}" />
-        </xalantest>    
-    </target>
+<target name="run.xalantest.transfact.normal" unless="gump">
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" >
+             <!-- bootclasspathref="boot.class.path" -->
+    <!-- Explicitly set TransformerFactory property to use -->
+    <sysproperty key="javax.xml.transform.TransformerFactory"
+                 value="${sysprop.transfact}" />
+  </xalantest>    
+</target>
 
-    <!-- ================================================================== -->
-    <!-- Initialize: setup for compiling, doc building, running tests       -->
-    <!-- ================================================================== -->
-    <target name="init.test"
+<target name="run.xalan-extension-test" >
+  <!--<antcall target="run.xalan-extension-test.gump"/>-->
+  <antcall target="run.xalan-extension-test.normal"/>
+</target>
+
+<target name="run.xalan-extension-test.gump" if="gump">
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" >
+             <!-- bootclasspathref="boot.class.path.gump" -->
+    <sysproperty key="org.apache.xalan.extensions.bsf.BSFManager"
+                 value="${sysprop.BSFManager}" />
+  </xalantest>
+</target>
+
+<target name="run.xalan-extension-test.normal">
+  <xalantest test="${testClass}"
+             testType="${testType}"
+             classpathref="${xalantest.classpathref}"
+             fork="${fork-tests}"
+             failonerror="${fail-on-error}" >
+             <!-- bootclasspathref="boot.class.path" -->
+    <sysproperty key="org.apache.xalan.extensions.bsf.BSFManager"
+                 value="${sysprop.BSFManager}" />
+</xalantest>    
+</target>
+
+<!-- ================================================================== -->
+<!-- Initialize: setup for compiling, doc building, running tests       -->
+<!-- ================================================================== -->
+<target name="init.test"
         description="Prepare timestamp, echo version for debugging">
-        <echo message="Using parserjar ${parserjar}" />
-        <tstamp />
-    </target>
+  <echo message="Using endorsed.parserjar ${endorsed.parserjar}" />
+  <echo message="Using parserjar ${parserjar}" />
+  <tstamp />
+</target>
 
-    <target name="init.build" depends="init.test"
+<target name="init.build" depends="init.test"
         description="Prepare build output tree, copy prebuilts">
-        <!-- Note this is case-sensitive, even on Windows! -->
-        <!-- Note JARDIR support should probably be removed, since it's a maintenance hassle Jul-02 -sc -->
-        <echo message="Your ==JARDIR== is set to ==${ENV.JARDIR}==" />
-        <!--<echo message="JVM Classpath is ${java.class.path}" />-->
-        <mkdir dir="${test.build.dir}" />
-        <mkdir dir="${test.build.dir}/${test.root}" />
-        <!-- Also copy over precompiled external processor wrapper classes -->
-        <copy todir="${test.build.dir}/${test.root}/xslwrapper" >
-            <fileset dir="${test.dir}xslwrapper">
-                <include name="**/*.class" />
-                <include name="**/*.properties" />
-            </fileset>
-        </copy>
-        <!-- Also copy over precompiled Ant class (why do we suddenly need this? -sc) -->
-        <copy todir="${test.build.dir}/${test.root}/xsl" >
-            <fileset dir="${test.dir}xsl">
-                <include name="**/*.class" />
-            </fileset>
-        </copy>
-    </target>
-         
-    <target name="init.docs" depends="init.build"
+  <!-- Note this is case-sensitive, even on Windows! -->
+  <!-- Note JARDIR support should probably be removed, since it's a maintenance hassle Jul-02 -sc -->
+  <echo message="Your ==JARDIR== is set to ==${ENV.JARDIR}==" />
+  <!--<echo message="JVM Classpath is ${java.class.path}" />-->
+  <mkdir dir="${test.build.dir}" />
+  <mkdir dir="${test.build.dir}/${test.root}" />
+  <!-- Also copy over precompiled external processor wrapper classes -->
+  <copy todir="${test.build.dir}/${test.root}/xslwrapper" >
+    <fileset dir="${test.dir}xslwrapper">
+      <include name="**/*.class" />
+      <include name="**/*.properties" />
+    </fileset>
+  </copy>
+  <!-- Also copy over precompiled Ant class (why do we suddenly need this? -sc) -->
+  <copy todir="${test.build.dir}/${test.root}/xsl" >
+    <fileset dir="${test.dir}xsl">
+      <include name="**/*.class" />
+    </fileset>
+  </copy>
+</target>
+
+<target name="init.docs" depends="init.build"
         description="Prepare output tree for documentation">
-        <mkdir dir="${test.build.apidocs}" />
-        <!-- Copy the Xalan-specific version of doc files and untargz them -->
-        <gunzip src="${xalan.generator.styletargz}" dest="${test.generator.styletar}"/>
-        <untar src="${test.generator.styletar}" dest="${test.xdocs.dir}"/>
-        <delete file="${test.generator.styletar}"/>
-    </target>
+  <mkdir dir="${test.build.apidocs}" />
+  <!-- Copy the Xalan-specific version of doc files and untargz them -->
+  <gunzip src="${xalan.generator.styletargz}" dest="${test.generator.styletar}"/>
+  <untar src="${test.generator.styletar}" dest="${test.xdocs.dir}"/>
+  <delete file="${test.generator.styletar}"/>
+</target>
 
 
-    <!-- ================================================================== -->
-    <!-- Run tests: the normal StylesheetTestletDriver on the conf suite    -->
-    <!-- ================================================================== -->
-    <target name="conf" description="Run TestletDriver over the conf tree"
-                             depends="init.test">
-        <!-- Set the default conformance test driver, user may override -->
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan conf test: ${testClass}" />
-        <property name="testType" value="conf." />
-
-        <mkdir dir="results-conf"/>
-
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="conf.class.path" />
-        </antcall>
-
-        <!--<property name="scan.outputDir" value="${conf.outputDir}"/>-->
-        <property name="scan.outputDir" value="results-conf"/>
-        <antcall target="scan"/>
-    </target>
-
-    <target name="conf.dom" description="Run TestletDriver over conf with DOM excludes">
-        <antcall target="conf">
-            <param name="conf.excludes" value="${trax.dom.excludes}"/>
-            <param name="conf.flavor" value="trax.dom"/>
-        </antcall>
-    </target>
-
-    <target name="conf.one" description="Run a single conf test">
-        <antcall target="conf">
-            <param name="testClass" value="org.apache.qetest.xsl.StylesheetDriver" />
-        </antcall>
-    </target>
-
-    <target name="conf.xsltc.dom" description="Run TestletDriver over conf with DOM excludes">
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.excludes" value="${trax.dom.excludes}"/>
-            <param name="conf.xsltc.flavor" value="trax.dom"/>
-        </antcall>
-    </target>
-
-    <target name="conf.trace" description="Run TestletDriver over the conf tree">
-        <property name="conf.trace" value="on"/>
-        <antcall target="conf"/>
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: the normal StylesheetTestletDriver on the EXSLT suite    -->
-    <!-- ================================================================== -->
-    <target name="exslt" description="Run TestletDriver over the exslt tree"
+<!-- ================================================================== -->
+<!-- Run tests: the normal StylesheetTestletDriver on the conf suite    -->
+<!-- ================================================================== -->
+<target name="conf" description="Run TestletDriver over the conf tree"
         depends="init.test">
-        <!-- Set the default conformance test driver, user may override -->
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan exslt test: ${testClass}" />
-        <property name="testType" value="exslt." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="exslt.class.path" />
-        </antcall>
-        <property name="scan.outputDir" value="${exslt.outputDir}"/>
-        <antcall target="scan"/>
-    </target>
+  <!-- Set the default conformance test driver, user may override -->
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan conf test: ${testClass}" />
+  <property name="testType" value="conf." />
 
-    <target name="exslt.dom" description="Run TestletDriver over exslt with DOM excludes">
-        <antcall target="exslt">
-            <param name="exslt.excludes" value="${trax.dom.excludes}"/>
-            <param name="exslt.flavor" value="trax.dom"/>
-        </antcall>
-    </target>
+  <mkdir dir="results-conf"/>
 
-    <target name="exslt.one" description="Run a single exslt test">
-        <antcall target="exslt">
-            <param name="testClass" value="org.apache.qetest.xsl.StylesheetDriver" />
-        </antcall>
-    </target>
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="conf.class.path" />
+  </antcall>
 
-    <target name="exslt.xsltc.dom" description="Run TestletDriver over exslt with DOM excludes">
-        <antcall target="exslt.xsltc">
-            <param name="exslt.xsltc.excludes" value="${trax.dom.excludes}"/>
-            <param name="exslt.xsltc.flavor" value="trax.dom"/>
-        </antcall>
-    </target>
+  <!--<property name="scan.outputDir" value="${conf.outputDir}"/>-->
+  <property name="scan.outputDir" value="results-conf"/>
+  <antcall target="scan"/>
+</target>
 
-    <target name="exslt.trace" description="Run TestletDriver over the conf tree">
-        <property name="exslt.trace" value="on"/>
-        <antcall target="exslt"/>
-    </target>
+<target name="conf.dom" description="Run TestletDriver over conf with DOM excludes">
+  <antcall target="conf">
+    <param name="conf.excludes" value="${trax.dom.excludes}"/>
+    <param name="conf.flavor" value="trax.dom"/>
+  </antcall>
+</target>
 
-    <!-- ================================================================== -->
-    <!-- Run tests: the normal StylesheetTestletDriver on the accept suite  -->
-    <!-- ================================================================== -->
-    <target name="accept" description="Run TestletDriver over the accept tree">
-        <!--<echo message="Executing Xalan accept test." />-->
-        
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan conf test: ${testClass}" />
+<target name="conf.one" description="Run a single conf test">
+  <antcall target="conf">
+    <param name="testClass" value="org.apache.qetest.xsl.StylesheetDriver" />
+  </antcall>
+</target>
 
-        <property name="qetest.summaryFile" value="Accept.xml" />
-        <property name="testType" value="accept." />
+<target name="conf.xsltc.dom" description="Run TestletDriver over conf with DOM excludes">
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.excludes" value="${trax.dom.excludes}"/>
+    <param name="conf.xsltc.flavor" value="trax.dom"/>
+  </antcall>
+</target>
 
-        <mkdir dir="results-accept"/>
+<target name="conf.trace" description="Run TestletDriver over the conf tree">
+  <property name="conf.trace" value="on"/>
+  <antcall target="conf"/>
+</target>
 
-        <!--<antcall target="conf"/>-->
-        <antcall target="run.xalantest">
-           <param name="xalantest.classpathref" value="conf.class.path" />
-        </antcall>
+<!-- ================================================================== -->
+<!-- Run tests: the normal StylesheetTestletDriver on the EXSLT suite    -->
+<!-- ================================================================== -->
+<target name="exslt" description="Run TestletDriver over the exslt tree"
+        depends="init.test">
+  <!-- Set the default conformance test driver, user may override -->
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan exslt test: ${testClass}" />
+  <property name="testType" value="exslt." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="exslt.class.path" />
+  </antcall>
+  <property name="scan.outputDir" value="${exslt.outputDir}"/>
+  <antcall target="scan"/>
+</target>
 
-        <property name="scan.outputDir" value="results-accept"/>
-        <antcall target="scan"/>
-    </target>
+<target name="exslt.dom" description="Run TestletDriver over exslt with DOM excludes">
+  <antcall target="exslt">
+    <param name="exslt.excludes" value="${trax.dom.excludes}"/>
+    <param name="exslt.flavor" value="trax.dom"/>
+</antcall>
+</target>
 
-    <!--<target name="accept.xsltc" description="Run TestletDriver over the accept tree">
-        <property name="testType" value="accept.xsltc." />
-        <property name="qetest.summaryFile" value="Accept.xml" />
-        <property name="scan.outputDir" value="${accept.xsltc.outputDir}"/>
-	    <property name="use-processor" value="${accept.xsltc.processor}"/>
-        <antcall target="conf.xsltc" />
+<target name="exslt.one" description="Run a single exslt test">
+  <antcall target="exslt">
+    <param name="testClass" value="org.apache.qetest.xsl.StylesheetDriver" />
+  </antcall>
+</target>
+
+<target name="exslt.xsltc.dom" description="Run TestletDriver over exslt with DOM excludes">
+  <antcall target="exslt.xsltc">
+    <param name="exslt.xsltc.excludes" value="${trax.dom.excludes}"/>
+    <param name="exslt.xsltc.flavor" value="trax.dom"/>
+  </antcall>
+</target>
+
+<target name="exslt.trace" description="Run TestletDriver over the conf tree">
+  <property name="exslt.trace" value="on"/>
+  <antcall target="exslt"/>
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: the normal StylesheetTestletDriver on the accept suite  -->
+<!-- ================================================================== -->
+<target name="accept" description="Run TestletDriver over the accept tree">
+  <!--<echo message="Executing Xalan accept test." />-->
+  
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan conf test: ${testClass}" />
+
+  <property name="qetest.summaryFile" value="Accept.xml" />
+  <property name="testType" value="accept." />
+
+  <mkdir dir="results-accept"/>
+
+  <!--<antcall target="conf"/>-->
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="conf.class.path" />
+  </antcall>
+
+  <property name="scan.outputDir" value="results-accept"/>
+  <antcall target="scan"/>
+</target>
+
+<!--<target name="accept.xsltc" description="Run TestletDriver over the accept tree">
+    <property name="testType" value="accept.xsltc." />
+    <property name="qetest.summaryFile" value="Accept.xml" />
+    <property name="scan.outputDir" value="${accept.xsltc.outputDir}"/>
+    <property name="use-processor" value="${accept.xsltc.processor}"/>
+    <antcall target="conf.xsltc" />
     </target>-->
 
     <target name="accept.trace" description="Run TestletDriver over the accept tree">
-        <property name="accept.trace" value="on"/>
-        <antcall target="accept"/>
+      <property name="accept.trace" value="on"/>
+      <antcall target="accept"/>
     </target>
 
     <!-- ================================================================== -->
     <!-- Run tests: the StylesheetErrorTestlet on the conferr suite         -->
     <!-- ================================================================== -->
     <target name="conferr" description="Run TestletDriver over the conferr negative test tree"
-        depends="init.test">
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan conf test: ${testClass}" />
-        <property name="testType" value="conferr." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="conf.class.path" />
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${conferr.outputDir}"/>
-        </antcall>
-    </target>
-
-
-    <target name="conferr.xsltc" description="Run TestletDriver over the conferr negative test tree" depends="init.test">
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan conferr test-xsltc: ${testClass}" />
-        <property name="testType" value="conferr.xsltc." />
-
-        <!-- Set indent-number to 0 to match Xalan's default indentation -->
-        <property name="${testType}Processor.setAttribute.indent-number" value="0" />
-
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="conf.class.path" />
-            <!-- Explicitly set TransformerFactory property to use xsltc -->
-            <param name="sysprop.transfact"
-                   value="org.apache.xalan.xsltc.trax.TransformerFactoryImpl" />
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${conferr.xsltc.outputDir}" />
-        </antcall>
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: the normal StylesheetTestletDriver on the perf suite    -->
-    <!-- ================================================================== -->
-    <target name="perf" description="Run TestletDriver over the perf tree"
-        depends="init.test">
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan perf test: ${testClass}" />
-        <property name="testType" value="perf." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="perf.class.path" />
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${perf.outputDir}"/>
-        </antcall>
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: the normal StylesheetTestletDriver on the contrib suite -->
-    <!-- ================================================================== -->
-    <target name="contrib" description="Run TestletDriver over the contrib tree"
-        depends="init.test">
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan contrib test: ${testClass}" />
-        <property name="testType" value="contrib." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="contrib.class.path" />
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${contrib.outputDir}"/>
-        </antcall>
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: the ThreadedTestletDriver on threads.filelist           -->
-    <!-- ================================================================== -->
-    <target name="threads" description="Run ThreadedTestletDriver on threads.filelist"
-        depends="init.test">
-        <!-- Set special threaded test driver and filelist, user may override -->
-        <property name="testClass" value="org.apache.qetest.xsl.ThreadedTestletDriver" />
-        <echo message="Executing Xalan threads test: ${testClass}" />
-        <property name="testType" value="threads." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="api.class.path" />
-        </antcall>
-    </target>
-
-
-    <!-- Run specific named API tests.
-    
-         What tests this build target runs, are defined within test.properties file
-         (please see the section, 'Various tests, that run for ant build.xml's "apitest" 
-          target' within ./test.properties file).
-    -->
-    <target name="apitest" description="Run specific API tests" depends="init.test">
-        <property name="testClass" value="org.apache.qetest.xsl.XSLTestHarness" />
-        <property name="testType" value="api." />
-        
-        <mkdir dir="results-api"/>
-        
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="api.class.path" />
-        </antcall>
-
-        <condition property="apitest-file-check-passed">
-            <and>
-               <available file="results-api/Pass-DOMResultAPITest.xml" />
-               <available file="results-api/Pass-DOMSourceAPITest.xml" />
-               <available file="results-api/Pass-DTMDumpTest.xml" />
-               <available file="results-api/Pass-EmbeddedStylesheetTest.xml" />
-               <available file="results-api/Pass-ErrorListenerAPITest.xml" />
-               <available file="results-api/Pass-ErrorListenerTest.xml" />               
-               <available file="results-api/Pass-SAXResultAPITest.xml" />
-               <available file="results-api/Pass-SAXSourceAPITest.xml" />
-               <available file="results-api/Pass-SAXTransformerFactoryAPITest.xml" />
-               <available file="results-api/Pass-SerializedStylesheetTest.xml" />                              
-               <available file="results-api/Pass-SystemIDResolverAPITest.xml" />
-               <available file="results-api/Pass-TemplatesHandlerAPITest.xml" />
-               <available file="results-api/Pass-TestDTM.xml" />
-               <available file="results-api/Pass-TestDTMIter.xml" />
-               <available file="results-api/Pass-TestDTMTrav.xml" />
-               <available file="results-api/Pass-TestXPathAPI.xml" />
-               <available file="results-api/Pass-TraceListenerTest.xml" />               
-               <available file="results-api/Pass-TransformerFactoryAPITest.xml" />
-               <available file="results-api/Pass-TransformerHandlerAPITest.xml" />
-               <available file="results-api/Pass-TransformerHandlerTest.xml" />
-               <available file="results-api/Pass-TransformStateAPITest.xml" />               
-               <available file="results-api/Pass-URIResolverTest.xml" />
-            </and>
-        </condition>
-
-        <antcall target="scan">
-            <!--<param name="scan.outputDir" value="${api.outputDir}"/>-->
-            <param name="scan.outputDir" value="results-api"/>
-        </antcall>
-        
-        <antcall target="apitest-pass-file-check"/>
-
-        <apiTestsResultTask resultDir="results-api" fileNamePrefix="Pass-"/>
-
-        <echo message=" [minitest] CONGRATULATIONS! The api tests passed!" />
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: Run all available API tests                             -->
-    <!-- ================================================================== -->
-    <target name="harness" description="Run all listed API harness.tests">
-        <antcall target="api">
-            <param name="testClass" value="org.apache.qetest.xsl.XSLTestHarness"/>
-            <param name="qetest.tests" value="${harness.tests}"/>
-            <!-- Below line is in case we run ThreadedTestletDriver -->
-            <param name="qetest.testlet" value="${harness.threads.testlet}"/>
-            <param name="qetest.fileList" value="${harness.threads.fileList}"/>
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${api.outputDir}"/>
-        </antcall>
-    </target>
-
-    <!-- ================================================================== -->
-    <!-- Run tests: all Bugzilla testlets to regress bugs                   -->
-    <!-- ================================================================== -->
-    <target name="bugzilla" description="Run all Bugzilla Testlets and tests to regress bugs"
-        depends="init.test">
-        <echo message="Executing Xalan Bugzilla Testlets and tests to regress bugs" />
-        <property name="testClass" value="org.apache.qetest.xsl.BugzillaTestletDriver" />
-        <property name="testType" value="bugzilla." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="bugzilla.class.path" />
-        </antcall>
-	<!-- Why isn't classes a dependency? -->
-        <echo message="If you got ClassNotFound, did you 'build bugzilla.classes' first?" />
-    </target>
-
-    <target name="jira" description="Run all Jira Testlets and tests to regress bugs"
-        depends="init.test">
-        <echo message="Executing Xalan Jira Testlets and tests to regress bugs" />
-        <property name="testClass" value="org.apache.qetest.xsl.JiraTestletDriver" />
-        <property name="testType" value="jira." />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="jira.class.path" />
-        </antcall>
-	<!-- Why isn't classes a dependency? -->
-        <echo message="If you got ClassNotFound, did you 'build jira.classes' first?" />
-    </target>
-
-    <!-- ============================================================== ==== -->
-    <!-- Run tests: various extensions tests                                -->
-    <!-- ================================================================== -->
-    <target name="extensions" 
-            description="Run extensions tests.  
-                         Non-Java extensions will use the Apache BSF implementation."
             depends="init.test">
-        <echo message="Executing Xalan extensions tests. Non-Java extensions will use the Apache BSF implementation." />
-        <!-- Set the default conformance test driver, user may 
-             override; note test.properties:extensions.testlet= 
-        -->
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <property name="testType" value="extensions." />
+      <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+      <echo message="Executing Xalan conf test: ${testClass}" />
+      <property name="testType" value="conferr." />
+      <antcall target="run.xalantest">
+        <param name="xalantest.classpathref" value="conf.class.path" />
+      </antcall>
+      <antcall target="scan">
+        <param name="scan.outputDir" value="${conferr.outputDir}"/>
+</antcall>
+</target>
 
-        <mkdir dir="results-extensions"/>
-        
-        <antcall target="run.xalan-extension-test">
-            <param name="xalantest.classpathref" value="extensions.class.path" />
-            <param name="sysprop.BSFManager" value="org.apache.bsf.BSFManager" />
-        </antcall>
-        <property name="scan.outputDir" value="results-extensions"/>
-        <antcall target="scan"/>
-        <echo message="If you got ClassNotFound, did you 'build extensions.classes' first?" />
-    </target>
 
-    <target name="extensions-with-ibm-bsf" 
-            description="Run extensions tests. 
-                         Non-Java extensions will use the IBM BSF implementation."
-            depends="init.test">
-        <echo message="Executing Xalan extensions tests.  Non-Java extensions will use the IBM BSF implementation." />
-        <!-- Set the default conformance test driver, user may 
-             override; note test.properties:extensions.testlet= 
-        -->
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <property name="testType" value="extensions.with-ibm-bsf." />
-        <property name="scan.outputDir" value="${extensions.with-ibm-bsf.outputDir}"/>
+<target name="conferr.xsltc" description="Run TestletDriver over the conferr negative test tree" depends="init.test">
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan conferr test-xsltc: ${testClass}" />
+  <property name="testType" value="conferr.xsltc." />
 
-        <antcall target="run.xalan-extension-test">
-            <param name="extensions.outputDir" value="${extensions.with-ibm-bsf.outputDir}" />
-            <param name="xalantest.classpathref" value="extensions.class.path" />
-            <param name="sysprop.BSFManager" value="com.ibm.bsf.BSFManager" />
-        </antcall>
-        <antcall target="scan"/>
-        <echo message="If you got ClassNotFound, did you 'build extensions.classes' first?" />
-    </target>
+  <!-- Set indent-number to 0 to match Xalan's default indentation -->
+  <property name="${testType}Processor.setAttribute.indent-number" value="0" />
 
-    <target name="rwapi" description="Run TestletDriver with xslt20 XPath2.0 RWAPI tests"
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="conf.class.path" />
+    <!-- Explicitly set TransformerFactory property to use xsltc -->
+    <param name="sysprop.transfact"
+           value="org.apache.xalan.xsltc.trax.TransformerFactoryImpl" />
+  </antcall>
+  <antcall target="scan">
+    <param name="scan.outputDir" value="${conferr.xsltc.outputDir}" />
+  </antcall>
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: the normal StylesheetTestletDriver on the perf suite    -->
+<!-- ================================================================== -->
+<target name="perf" description="Run TestletDriver over the perf tree"
+        depends="init.test">
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan perf test: ${testClass}" />
+  <property name="testType" value="perf." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="perf.class.path" />
+  </antcall>
+  <antcall target="scan">
+    <param name="scan.outputDir" value="${perf.outputDir}"/>
+  </antcall>
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: the normal StylesheetTestletDriver on the contrib suite -->
+<!-- ================================================================== -->
+<target name="contrib" description="Run TestletDriver over the contrib tree"
+        depends="init.test">
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan contrib test: ${testClass}" />
+  <property name="testType" value="contrib." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="contrib.class.path" />
+  </antcall>
+  <antcall target="scan">
+    <param name="scan.outputDir" value="${contrib.outputDir}"/>
+  </antcall>
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: the ThreadedTestletDriver on threads.filelist           -->
+<!-- ================================================================== -->
+<target name="threads" description="Run ThreadedTestletDriver on threads.filelist"
+        depends="init.test">
+  <!-- Set special threaded test driver and filelist, user may override -->
+  <property name="testClass" value="org.apache.qetest.xsl.ThreadedTestletDriver" />
+  <echo message="Executing Xalan threads test: ${testClass}" />
+  <property name="testType" value="threads." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="api.class.path" />
+  </antcall>
+</target>
+
+
+<!-- Run specific named API tests.
+     
+     What tests this build target runs, are defined within test.properties file
+     (please see the section, 'Various tests, that run for ant build.xml's "apitest" 
+     target' within ./test.properties file).
+-->
+<target name="apitest" description="Run specific API tests" depends="init.test">
+  <property name="testClass" value="org.apache.qetest.xsl.XSLTestHarness" />
+  <property name="testType" value="api." />
+  
+  <mkdir dir="results-api"/>
+  
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="api.class.path" />
+  </antcall>
+
+  <condition property="apitest-file-check-passed">
+    <and>
+      <available file="results-api/Pass-DOMResultAPITest.xml" />
+      <available file="results-api/Pass-DOMSourceAPITest.xml" />
+      <available file="results-api/Pass-DTMDumpTest.xml" />
+      <available file="results-api/Pass-EmbeddedStylesheetTest.xml" />
+      <available file="results-api/Pass-ErrorListenerAPITest.xml" />
+      <available file="results-api/Pass-ErrorListenerTest.xml" />               
+      <available file="results-api/Pass-SAXResultAPITest.xml" />
+      <available file="results-api/Pass-SAXSourceAPITest.xml" />
+      <available file="results-api/Pass-SAXTransformerFactoryAPITest.xml" />
+      <available file="results-api/Pass-SerializedStylesheetTest.xml" />                              
+      <available file="results-api/Pass-SystemIDResolverAPITest.xml" />
+      <available file="results-api/Pass-TemplatesHandlerAPITest.xml" />
+      <available file="results-api/Pass-TestDTM.xml" />
+      <available file="results-api/Pass-TestDTMIter.xml" />
+      <available file="results-api/Pass-TestDTMTrav.xml" />
+      <available file="results-api/Pass-TestXPathAPI.xml" />
+      <available file="results-api/Pass-TraceListenerTest.xml" />               
+      <available file="results-api/Pass-TransformerFactoryAPITest.xml" />
+      <available file="results-api/Pass-TransformerHandlerAPITest.xml" />
+      <available file="results-api/Pass-TransformerHandlerTest.xml" />
+      <available file="results-api/Pass-TransformStateAPITest.xml" />               
+      <available file="results-api/Pass-URIResolverTest.xml" />
+    </and>
+  </condition>
+
+  <antcall target="scan">
+    <!--<param name="scan.outputDir" value="${api.outputDir}"/>-->
+    <param name="scan.outputDir" value="results-api"/>
+</antcall>
+
+<antcall target="apitest-pass-file-check"/>
+
+<apiTestsResultTask resultDir="results-api" fileNamePrefix="Pass-"/>
+
+<echo message=" [minitest] CONGRATULATIONS! The api tests passed!" />
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: Run all available API tests                             -->
+<!-- ================================================================== -->
+<target name="harness" description="Run all listed API harness.tests">
+  <antcall target="api">
+    <param name="testClass" value="org.apache.qetest.xsl.XSLTestHarness"/>
+    <param name="qetest.tests" value="${harness.tests}"/>
+    <!-- Below line is in case we run ThreadedTestletDriver -->
+    <param name="qetest.testlet" value="${harness.threads.testlet}"/>
+    <param name="qetest.fileList" value="${harness.threads.fileList}"/>
+</antcall>
+<antcall target="scan">
+  <param name="scan.outputDir" value="${api.outputDir}"/>
+</antcall>
+</target>
+
+<!-- ================================================================== -->
+<!-- Run tests: all Bugzilla testlets to regress bugs                   -->
+<!-- ================================================================== -->
+<target name="bugzilla" description="Run all Bugzilla Testlets and tests to regress bugs"
+        depends="init.test">
+  <echo message="Executing Xalan Bugzilla Testlets and tests to regress bugs" />
+  <property name="testClass" value="org.apache.qetest.xsl.BugzillaTestletDriver" />
+  <property name="testType" value="bugzilla." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="bugzilla.class.path" />
+  </antcall>
+  <!-- Why isn't classes a dependency? -->
+  <echo message="If you got ClassNotFound, did you 'build bugzilla.classes' first?" />
+</target>
+
+<target name="jira" description="Run all Jira Testlets and tests to regress bugs"
+        depends="init.test">
+  <echo message="Executing Xalan Jira Testlets and tests to regress bugs" />
+  <property name="testClass" value="org.apache.qetest.xsl.JiraTestletDriver" />
+  <property name="testType" value="jira." />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="jira.class.path" />
+  </antcall>
+  <!-- Why isn't classes a dependency? -->
+  <echo message="If you got ClassNotFound, did you 'build jira.classes' first?" />
+</target>
+
+<!-- ============================================================== ==== -->
+<!-- Run tests: various extensions tests                                -->
+<!-- ================================================================== -->
+<target name="extensions" 
+        description="Run extensions tests.  
+                     Non-Java extensions will use the Apache BSF implementation."
+        depends="init.test">
+  <echo message="Executing Xalan extensions tests. Non-Java extensions will use the Apache BSF implementation." />
+  <!-- Set the default conformance test driver, user may 
+       override; note test.properties:extensions.testlet= 
+  -->
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <property name="testType" value="extensions." />
+
+  <mkdir dir="results-extensions"/>
+  
+  <antcall target="run.xalan-extension-test">
+    <param name="xalantest.classpathref" value="extensions.class.path" />
+    <param name="sysprop.BSFManager" value="org.apache.bsf.BSFManager" />
+  </antcall>
+  <property name="scan.outputDir" value="results-extensions"/>
+  <antcall target="scan"/>
+  <echo message="If you got ClassNotFound, did you 'build extensions.classes' first?" />
+</target>
+
+<target name="extensions-with-ibm-bsf" 
+        description="Run extensions tests. 
+                     Non-Java extensions will use the IBM BSF implementation."
+        depends="init.test">
+  <echo message="Executing Xalan extensions tests.  Non-Java extensions will use the IBM BSF implementation." />
+  <!-- Set the default conformance test driver, user may 
+       override; note test.properties:extensions.testlet= 
+  -->
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <property name="testType" value="extensions.with-ibm-bsf." />
+  <property name="scan.outputDir" value="${extensions.with-ibm-bsf.outputDir}"/>
+
+  <antcall target="run.xalan-extension-test">
+    <param name="extensions.outputDir" value="${extensions.with-ibm-bsf.outputDir}" />
+    <param name="xalantest.classpathref" value="extensions.class.path" />
+    <param name="sysprop.BSFManager" value="com.ibm.bsf.BSFManager" />
+  </antcall>
+  <antcall target="scan"/>
+  <echo message="If you got ClassNotFound, did you 'build extensions.classes' first?" />
+</target>
+
+<target name="rwapi" description="Run TestletDriver with xslt20 XPath2.0 RWAPI tests"
         depends="init.test,compile.rwapi,jar">
-        <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
-        <echo message="Executing Xalan conf test: ${testClass}" />
-        <property name="testType" value="conf." />
-        <property name="conf.testlet" value="org.apache.qetest.rwapi.XPathASTTestlet" />
-        <antcall target="run.xalantest">
-            <param name="xalantest.classpathref" value="rwapitest.class.path" />
-        </antcall>
-        <property name="scan.outputDir" value="${conf.outputDir}"/>
-        <antcall target="scan"/>
-    </target>
-    <!-- ================================================================== -->
-    <!-- Run tests: Run the Xalan-J 2.x Minitest                            -->
-    <!-- ================================================================== -->
-    <!-- This target doesn't actually do anything itself - it merely 
-         depends on other targets, in order, to first run the whole 
-         Minitest, then to log to Ant whether the test didn't pass 
-         (i.e. failed, incomplete, error or ambiguous) or passed.
-    -->
-    <target name="minitest" 
-            description="Run the Xalan-J 2.x Minitest"
-            depends="minitest-execute,minitest-notpass,minitest-pass">
-    </target>
+  <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
+  <echo message="Executing Xalan conf test: ${testClass}" />
+  <property name="testType" value="conf." />
+  <property name="conf.testlet" value="org.apache.qetest.rwapi.XPathASTTestlet" />
+  <antcall target="run.xalantest">
+    <param name="xalantest.classpathref" value="rwapitest.class.path" />
+</antcall>
+<property name="scan.outputDir" value="${conf.outputDir}"/>
+<antcall target="scan"/>
+</target>
+<!-- ================================================================== -->
+<!-- Run tests: Run the Xalan-J 2.x Minitest                            -->
+<!-- ================================================================== -->
+<!-- This target doesn't actually do anything itself - it merely 
+     depends on other targets, in order, to first run the whole 
+     Minitest, then to log to Ant whether the test didn't pass 
+     (i.e. failed, incomplete, error or ambiguous) or passed.
+-->
+<target name="minitest" 
+        description="Run the Xalan-J 2.x Minitest"
+        depends="minitest-execute,minitest-notpass,minitest-pass">
+</target>
 
-    <target name="minitest.gump" 
-            description="Compile and Run the Xalan-J 2.x Minitest"
-            depends="jar">
-       <antcall target="minitest">
-         <param name="gump" value="boot.class.path.gump"/>
-       </antcall>            
-    </target>
-    <target name="minitest-execute">
-        <echo message="About to execute the Minitest..." />
-        <antcall target="api">
-            <param name="testClass" value="org.apache.qetest.trax.Minitest"/>
-            <param name="testType" value="minitest."/>
-        </antcall>
-        <available file="${minitest.passFile}" property="minitest-passed" />
-    </target>
-    <target name="minitest-notpass" unless="minitest-passed">
-        <echo message=" [minitest] ERROR! The Minitest failed!" />
-        <echo message=" [minitest] See details in ${minitest.logFile}, output is in ${minitest.outputDir}" />
-        <echo message=" [minitest] Please fix any Minitest problems before checking in!" />
-        <fail message="Please fix any Minitest problems before checking in!" />
-    </target>
-    <target name="minitest-pass" if="minitest-passed">
-        <echo message=" [minitest] CONGRATULATIONS! The Minitest passed!" />
-        <echo message=" [minitest] See details in ${minitest.logFile}" />
-    </target>
+<target name="minitest.gump" 
+        description="Compile and Run the Xalan-J 2.x Minitest"
+        depends="jar">
+  <antcall target="minitest">
+    <param name="gump" value="boot.class.path.gump"/>
+</antcall>            
+</target>
+<target name="minitest-execute">
+  <echo message="About to execute the Minitest..." />
+  <antcall target="api">
+    <param name="testClass" value="org.apache.qetest.trax.Minitest"/>
+    <param name="testType" value="minitest."/>
+</antcall>
+<available file="${minitest.passFile}" property="minitest-passed" />
+</target>
+<target name="minitest-notpass" unless="minitest-passed">
+  <echo message=" [minitest] ERROR! The Minitest failed!" />
+  <echo message=" [minitest] See details in ${minitest.logFile}, output is in ${minitest.outputDir}" />
+  <echo message=" [minitest] Please fix any Minitest problems before checking in!" />
+  <fail message="Please fix any Minitest problems before checking in!" />
+</target>
+<target name="minitest-pass" if="minitest-passed">
+  <echo message=" [minitest] CONGRATULATIONS! The Minitest passed!" />
+  <echo message=" [minitest] See details in ${minitest.logFile}" />
+</target>
 
-    <!-- ================================================================== -->
-    <!-- Run tests: Run the Xalan-J 2.x Smoketest, including several tests  -->
-    <!-- Note: this target is frequently called from outside of this file!  -->
-    <!-- ================================================================== -->
-    <!--<target name="smoketest" 
-            description="Run the Xalan-J 2.x Smoketest"
-            depends="minitest-execute,extensions.classes,smoketest-execute,minitest-notpass,minitest-pass,smoketest-notpass,smoketest-pass">
+<!-- ================================================================== -->
+<!-- Run tests: Run the Xalan-J 2.x Smoketest, including several tests  -->
+<!-- Note: this target is frequently called from outside of this file!  -->
+<!-- ================================================================== -->
+<!--<target name="smoketest" 
+    description="Run the Xalan-J 2.x Smoketest"
+    depends="minitest-execute,extensions.classes,smoketest-execute,minitest-notpass,minitest-pass,smoketest-notpass,smoketest-pass">
     </target>-->
     <target name="smoketest" 
             description="Run the Xalan-J 2.x Smoketest"
             depends="smoketest-execute,smoketest-notpass,smoketest-pass">
-    </target>
-    <target name="smoketest.xsltc" 
-            description="Run the Xalan-J 2.x XSLTC Smoketest"
-            depends="jar,smoketest.xsltc-execute,smoketest.xsltc-notpass,smoketest.xsltc-pass">
-    </target>
-    
-    <!-- The following compiles the minimum to run the smoketests, runs them, 
-         and creates distros just of the results and existing tree, 
-         without actually running the docs - this is to ensure that 
-         doc build errors in the tests won't affect GUMP runs.
-    -->
-    <target name="smoketest.dev" 
-            description="Run the Xalan-J 2.x Smoketest with dependencies"
-            depends="jar,minitest-execute,extensions.classes,smoketest-execute,minitest-notpass,minitest-pass,smoketest-notpass,smoketest-pass">        
-    </target>
+</target>
+<target name="smoketest.xsltc" 
+        description="Run the Xalan-J 2.x XSLTC Smoketest"
+        depends="jar,smoketest.xsltc-execute,smoketest.xsltc-notpass,smoketest.xsltc-pass">
+</target>
 
-    <target name="smoketest.gump" 
-            description="Run the Xalan-J 2.x Smoketest in automated builds with dependencies">
-       <antcall target="minitest.gump">
-         <param name="gump" value="boot.class.path.gump"/>
-       </antcall>    
-       <antcall target="extensions.classes"/>      
-       <antcall target="smoketest-execute.gump">
-         <param name="gump" value="boot.class.path.gump"/>
-       </antcall>  
-       
-        <!-- This compiles the minimum to run the smoketests, runs them, 
-             and creates distros just of the results and existing tree, 
-             without actually running the docs - this is to ensure that 
-             doc build errors in the tests won't affect GUMP runs.
-        -->
-    </target>
-    
-    <!-- This target smoketest-execute.gump is a subtarget which is called
-         from smoketest.gump. 
-    -->
-    <target name="smoketest-execute.gump" 
-            description="Run the Xalan-J 2.x Smoketest for Gump build "
-            depends="smoketest-execute,smoketest-results-dist,dist-nodeps,
-            smoketest-notpass,smoketest-pass">
-    </target>    
+<!-- The following compiles the minimum to run the smoketests, runs them, 
+     and creates distros just of the results and existing tree, 
+     without actually running the docs - this is to ensure that 
+     doc build errors in the tests won't affect GUMP runs.
+-->
+<target name="smoketest.dev" 
+        description="Run the Xalan-J 2.x Smoketest with dependencies"
+        depends="jar,minitest-execute,extensions.classes,smoketest-execute,minitest-notpass,minitest-pass,smoketest-notpass,smoketest-pass">        
+</target>
 
-    <target name="smoketest-execute">
-        <echo message="About to execute XalanJ2 extensions tests..." />
-        <antcall target="extensions">
-            <param name="testType" value="smoketest.extensions."/>
-        </antcall>
+<target name="smoketest.gump" 
+        description="Run the Xalan-J 2.x Smoketest in automated builds with dependencies">
+  <antcall target="minitest.gump">
+    <param name="gump" value="boot.class.path.gump"/>
+  </antcall>    
+  <antcall target="extensions.classes"/>      
+  <antcall target="smoketest-execute.gump">
+    <param name="gump" value="boot.class.path.gump"/>
+  </antcall>  
+  
+  <!-- This compiles the minimum to run the smoketests, runs them, 
+       and creates distros just of the results and existing tree, 
+       without actually running the docs - this is to ensure that 
+       doc build errors in the tests won't affect GUMP runs.
+  -->
+</target>
 
-        <echo message="About to execute Conformance tests..." />
-        <antcall target="conf">
-            <param name="testType" value="smoketest.conf."/>
-        </antcall>
+<!-- This target smoketest-execute.gump is a subtarget which is called
+     from smoketest.gump. 
+-->
+<target name="smoketest-execute.gump" 
+        description="Run the Xalan-J 2.x Smoketest for Gump build "
+        depends="smoketest-execute,smoketest-results-dist,dist-nodeps,
+                 smoketest-notpass,smoketest-pass">
+</target>    
 
-        <echo message="About to execute Accept tests..." />
-        <antcall target="accept">
-            <param name="testType" value="smoketest.accept."/>
-        </antcall>
+<target name="smoketest-execute">
+  <echo message="About to execute XalanJ2 extensions tests..." />
+  <antcall target="extensions">
+    <param name="testType" value="smoketest.extensions."/>
+</antcall>
 
-        <condition property="smoketest-passed">
-            <and>
-               <available file="${smoketest.extensions.passFile}" />
-               <available file="${smoketest.conf.passFile}" />
-               <available file="${smoketest.accept.passFile}" />              
-            </and>
-        </condition>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="smoketest"/>
-        </antcall>
-    </target>
+<echo message="About to execute Conformance tests..." />
+<antcall target="conf">
+  <param name="testType" value="smoketest.conf."/>
+</antcall>
 
-    <target name="smoketest.xsltc-execute">
-        <echo message="About to execute Conformance tests..." />
-        <antcall target="conf.xsltc">
-            <param name="testType" value="smoketest.xsltc.conf."/>
-        </antcall>
+<echo message="About to execute Accept tests..." />
+<antcall target="accept">
+  <param name="testType" value="smoketest.accept."/>
+</antcall>
 
-        <!--<echo message="About to execute Accept tests..." />
-        <antcall target="accept.xsltc">
-            <param name="testType" value="smoketest.xsltc.accept."/>
+<condition property="smoketest-passed">
+  <and>
+    <available file="${smoketest.extensions.passFile}" />
+    <available file="${smoketest.conf.passFile}" />
+    <available file="${smoketest.accept.passFile}" />              
+  </and>
+</condition>
+<antcall target="scan">
+  <param name="scan.outputDir" value="smoketest"/>
+</antcall>
+</target>
+
+<target name="smoketest.xsltc-execute">
+  <echo message="About to execute Conformance tests..." />
+  <antcall target="conf.xsltc">
+    <param name="testType" value="smoketest.xsltc.conf."/>
+  </antcall>
+
+  <!--<echo message="About to execute Accept tests..." />
+      <antcall target="accept.xsltc">
+        <param name="testType" value="smoketest.xsltc.accept."/>
         </antcall>-->
 
         <condition property="smoketest.xsltc-passed">
-            <and>
-                <available file="${smoketest.xsltc.conf.passFile}" />
-                <!--<available file="${smoketest.xsltc.accept.passFile}" />-->
-            </and>
+          <and>
+            <available file="${smoketest.xsltc.conf.passFile}" />
+            <!--<available file="${smoketest.xsltc.accept.passFile}" />-->
+          </and>
         </condition>
         <antcall target="scan">
-            <param name="scan.outputDir" value="smoketest.xsltc"/>
-        </antcall>
-    </target>
+          <param name="scan.outputDir" value="smoketest.xsltc"/>
+</antcall>
+</target>
 
-    <target name="smoketest-notpass" unless="smoketest-passed">
-        <echo message=" [minitest] ERROR! The Smoketest failed!" />
-        <echo message=" [minitest] See details in ${smoketest.conf.logFile}, output is in ${smoketest.conf.outputDir}" />
-        <echo message=" [minitest] See details in ${smoketest.api.logFile}, output is in ${smoketest.api.outputDir}" />
-        <echo message=" [minitest] See details in ${smoketest.extensions.logFile}, output is in ${smoketest.extensions.outputDir}" />
-        <echo message=" [minitest] Please fix any smoketest problems before checking in!" />
-        <fail message="Please fix any smoketest problems before checking in!" />
-    </target>
-    
-    <target name="smoketest-pass" if="smoketest-passed">
-        <echo message=" [minitest] CONGRATULATIONS! The Smoketest passed!" />        
-        <echo message=" [minitest] Details are in ${smoketest.extensions.logFile}, ${smoketest.conf.logFile}, ${smoketest.accept.logFile}" />
-    </target>
+<target name="smoketest-notpass" unless="smoketest-passed">
+  <echo message=" [minitest] ERROR! The Smoketest failed!" />
+  <echo message=" [minitest] See details in ${smoketest.conf.logFile}, output is in ${smoketest.conf.outputDir}" />
+  <echo message=" [minitest] See details in ${smoketest.api.logFile}, output is in ${smoketest.api.outputDir}" />
+  <echo message=" [minitest] See details in ${smoketest.extensions.logFile}, output is in ${smoketest.extensions.outputDir}" />
+  <echo message=" [minitest] Please fix any smoketest problems before checking in!" />
+  <fail message="Please fix any smoketest problems before checking in!" />
+</target>
 
-    <target name="apitest-pass-file-check" unless="apitest-file-check-passed">
-       <echo message=" [minitest] ERROR! The api tests failed!" />
-       <fail message="Please fix any api tests problems before checking in!" />       
-    </target>
+<target name="smoketest-pass" if="smoketest-passed">
+  <echo message=" [minitest] CONGRATULATIONS! The Smoketest passed!" />        
+  <echo message=" [minitest] Details are in ${smoketest.extensions.logFile}, ${smoketest.conf.logFile}, ${smoketest.accept.logFile}" />
+</target>
 
-    <target name="smoketest.xsltc-notpass" unless="smoketest.xsltc-passed">
-        <echo message=" [minitest] ERROR! The Smoketest failed!" />
-        <echo message=" [minitest] See details in ${smoketest.xsltc.conf.logFile}, output is in ${smoketest.xsltc.conf.outputDir}" />
-        <echo message=" [minitest] See details in ${smoketest.xsltc.accept.logFile}, output is in ${smoketest.xsltc.accept.outputDir}" />
-        <echo message=" [minitest] Please fix any smoketest problems before checking in!" />
-        <fail message="Please fix any smoketest problems before checking in!" />
-    </target>
-    <target name="smoketest.xsltc-pass" if="smoketest.xsltc-passed">
-        <echo message=" [minitest] CONGRATULATIONS! The Smoketest passed!" />
-        <echo message=" [minitest] Details are in ${smoketest.xsltc.conf.logFile}, ${smoketest.xsltc.accept.logFile}" />
-    </target>
+<target name="apitest-pass-file-check" unless="apitest-file-check-passed">
+  <echo message=" [minitest] ERROR! The api tests failed!" />
+  <fail message="Please fix any api tests problems before checking in!" />       
+</target>
 
-    <target name="smoketest-results-dist" depends="init.test">
-        <property name="tarzip-backref" value="../.."/>
-        <property name="tarzip-fwdref" value="xml-xalan/test"/>
-        <!-- tar.gz the automation and batch files, etc. -->
-        <!-- # smoketest parent output location: used in test.properties/build.xml -->
-        <tar tarfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar">
-          <tarfileset dir="${tarzip-backref}">
-            <include name="${tarzip-fwdref}/${smoketest.outputDir}/"/>
-          </tarfileset>
-        </tar>
-        <gzip src="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar" 
-              zipfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar.gz"/>
-        <delete file="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar"/>
-              
-        <zip zipfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.zip" >
-          <zipfileset dir="${tarzip-backref}">
-            <include name="${tarzip-fwdref}/${smoketest.outputDir}/"/>
-          </zipfileset>
-        </zip>
-    </target>
+<target name="smoketest.xsltc-notpass" unless="smoketest.xsltc-passed">
+  <echo message=" [minitest] ERROR! The Smoketest failed!" />
+  <echo message=" [minitest] See details in ${smoketest.xsltc.conf.logFile}, output is in ${smoketest.xsltc.conf.outputDir}" />
+  <echo message=" [minitest] See details in ${smoketest.xsltc.accept.logFile}, output is in ${smoketest.xsltc.accept.outputDir}" />
+  <echo message=" [minitest] Please fix any smoketest problems before checking in!" />
+  <fail message="Please fix any smoketest problems before checking in!" />
+</target>
+<target name="smoketest.xsltc-pass" if="smoketest.xsltc-passed">
+  <echo message=" [minitest] CONGRATULATIONS! The Smoketest passed!" />
+  <echo message=" [minitest] Details are in ${smoketest.xsltc.conf.logFile}, ${smoketest.xsltc.accept.logFile}" />
+</target>
 
-    <!-- ================================================================== -->
-    <!-- Run tests: A whole bunch of tests - used before posting builds, etc-->
-    <!-- ================================================================== -->
-    <target name="alltest" 
-            description="Run nearly *all* available Xalan-J 2.x tests with defaults"
-            depends="all,alltest.other,alltest.conf,alltest.accept,alltest.contrib">
-        <!-- Ensure that one last scan gets run of the whole output set
-             (Note that when we call sub-targets, some of our subdirs 
-             may have had sub-scans done as well) -->
-        <antcall target="scan">
-            <param name="scan.outputDir" value="results-alltest"/>
-        </antcall>
+<target name="smoketest-results-dist" depends="init.test">
+  <property name="tarzip-backref" value="../.."/>
+  <property name="tarzip-fwdref" value="xml-xalan/test"/>
+  <!-- tar.gz the automation and batch files, etc. -->
+  <!-- # smoketest parent output location: used in test.properties/build.xml -->
+  <tar tarfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar">
+    <tarfileset dir="${tarzip-backref}">
+      <include name="${tarzip-fwdref}/${smoketest.outputDir}/"/>
+    </tarfileset>
+  </tar>
+  <gzip src="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar" 
+        zipfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar.gz"/>
+  <delete file="${test.build.dir}/xalan-smoketest-${DSTAMP}.tar"/>
+  
+  <zip zipfile="${test.build.dir}/xalan-smoketest-${DSTAMP}.zip" >
+    <zipfileset dir="${tarzip-backref}">
+      <include name="${tarzip-fwdref}/${smoketest.outputDir}/"/>
+</zipfileset>
+</zip>
+</target>
 
-    </target>
-    <target name="alltest.features" 
-            description="Re-Run nearly *all* available Xalan-J 2.x tests with setAttribute features set"
-            depends="all,alltest.other">
-        <property name="alltest.resultDir" value="results-alltest" />
-        <antcall target="alltest.conf">
-            <param name="alltest.resultDir" value="${alltest.resultDir}/inctrue"/>
-            <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/incremental" value="true"/>
-        </antcall>
-        <antcall target="alltest.conf">
-            <param name="alltest.resultDir" value="${alltest.resultDir}/optfalse"/>
-            <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/optimize" value="false"/>
-        </antcall>
-        <antcall target="alltest.contrib">
-            <param name="alltest.resultDir" value="${alltest.resultDir}/inctrue"/>
-            <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/incremental" value="true"/>
-        </antcall>
-        <antcall target="alltest.contrib">
-            <param name="alltest.resultDir" value="${alltest.resultDir}/optfalse"/>
-            <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/optimize" value="false"/>
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${alltest.resultDir}"/>
-        </antcall>
-    </target>
+<!-- ================================================================== -->
+<!-- Run tests: A whole bunch of tests - used before posting builds, etc-->
+<!-- ================================================================== -->
+<target name="alltest" 
+        description="Run nearly *all* available Xalan-J 2.x tests with defaults"
+        depends="all,alltest.other,alltest.conf,alltest.accept,alltest.contrib">
+  <!-- Ensure that one last scan gets run of the whole output set
+       (Note that when we call sub-targets, some of our subdirs 
+       may have had sub-scans done as well) -->
+  <antcall target="scan">
+    <param name="scan.outputDir" value="results-alltest"/>
+  </antcall>
 
-    <target name="alltest.other">
-        <property name="alltest.resultDir" value="results-alltest" />
-        <echo message="About to execute various API, extensions, bugzilla tests, jira tests, results under ${alltest.resultDir}/..." />
-        <!-- Run all individual API tests through the harness -->
-        <antcall target="harness">
-            <param name="api.outputDir" value="${alltest.resultDir}/harness"/>
-            <param name="api.logFile" value="${alltest.resultDir}/harness/results.xml"/>
-        </antcall>
-        <!-- Run other misc tests -->
-        <antcall target="extensions">
-            <param name="extensions.outputDir" value="${alltest.resultDir}/extensions"/>
-            <param name="extensions.logFile" value="${alltest.resultDir}/extensions/results.xml"/>
-        </antcall>
-        <antcall target="bugzilla">
-            <param name="bugzilla.outputDir" value="${alltest.resultDir}/bugzilla"/>
-            <param name="bugzilla.logFile" value="${alltest.resultDir}/bugzilla/results.xml"/>
-        </antcall>
-        <antcall target="jira">
-            <param name="jira.outputDir" value="${alltest.resultDir}/jira"/>
-            <param name="jira.logFile" value="${alltest.resultDir}/jira/results.xml"/>
-        </antcall>
-        <!-- Run the threading tests once -->
-        <antcall target="threads">
-            <param name="threads.outputDir" value="${alltest.resultDir}/threads"/>
-            <param name="threads.logFile" value="${alltest.resultDir}/threads/results.xml"/>
-        </antcall>
-        <!-- Run the perf tests just with streams, which gives best perf data -->
-        <antcall target="perf">
-            <param name="perf.flavor" value="trax.stream"/>
-			<param name="perf.fileList" value="perf.filelist"/>
-            <param name="perf.outputDir" value="${alltest.resultDir}/perf"/>
-            <param name="perf.logFile" value="${alltest.resultDir}/perf/results.xml"/>
-        </antcall>
-        <antcall target="scan">
-            <param name="scan.outputDir" value="${alltest.resultDir}"/>
-        </antcall>
-    </target>
+</target>
+<target name="alltest.features" 
+        description="Re-Run nearly *all* available Xalan-J 2.x tests with setAttribute features set"
+        depends="all,alltest.other">
+  <property name="alltest.resultDir" value="results-alltest" />
+  <antcall target="alltest.conf">
+    <param name="alltest.resultDir" value="${alltest.resultDir}/inctrue"/>
+    <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/incremental" value="true"/>
+  </antcall>
+  <antcall target="alltest.conf">
+    <param name="alltest.resultDir" value="${alltest.resultDir}/optfalse"/>
+    <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/optimize" value="false"/>
+  </antcall>
+  <antcall target="alltest.contrib">
+    <param name="alltest.resultDir" value="${alltest.resultDir}/inctrue"/>
+    <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/incremental" value="true"/>
+  </antcall>
+  <antcall target="alltest.contrib">
+    <param name="alltest.resultDir" value="${alltest.resultDir}/optfalse"/>
+    <param name="conf.Processor.setAttribute.http://xml.apache.org/xalan/features/optimize" value="false"/>
+</antcall>
+<antcall target="scan">
+  <param name="scan.outputDir" value="${alltest.resultDir}"/>
+</antcall>
+</target>
 
-    <target name="alltest.contrib">
-        <property name="alltest.resultDir" value="results-alltest" />
-        <property name="alltest.contrib.resultDir" value="${alltest.resultDir}/contrib" />
-        <echo message="About to execute contrib tests with all flavors, results into ${alltest.contrib.resultDir}/..." />
+<target name="alltest.other">
+  <property name="alltest.resultDir" value="results-alltest" />
+  <echo message="About to execute various API, extensions, bugzilla tests, jira tests, results under ${alltest.resultDir}/..." />
+  <!-- Run all individual API tests through the harness -->
+  <antcall target="harness">
+    <param name="api.outputDir" value="${alltest.resultDir}/harness"/>
+    <param name="api.logFile" value="${alltest.resultDir}/harness/results.xml"/>
+  </antcall>
+  <!-- Run other misc tests -->
+  <antcall target="extensions">
+    <param name="extensions.outputDir" value="${alltest.resultDir}/extensions"/>
+    <param name="extensions.logFile" value="${alltest.resultDir}/extensions/results.xml"/>
+  </antcall>
+  <antcall target="bugzilla">
+    <param name="bugzilla.outputDir" value="${alltest.resultDir}/bugzilla"/>
+    <param name="bugzilla.logFile" value="${alltest.resultDir}/bugzilla/results.xml"/>
+  </antcall>
+  <antcall target="jira">
+    <param name="jira.outputDir" value="${alltest.resultDir}/jira"/>
+    <param name="jira.logFile" value="${alltest.resultDir}/jira/results.xml"/>
+  </antcall>
+  <!-- Run the threading tests once -->
+  <antcall target="threads">
+    <param name="threads.outputDir" value="${alltest.resultDir}/threads"/>
+    <param name="threads.logFile" value="${alltest.resultDir}/threads/results.xml"/>
+</antcall>
+<!-- Run the perf tests just with streams, which gives best perf data -->
+<antcall target="perf">
+  <param name="perf.flavor" value="trax.stream"/>
+  <param name="perf.fileList" value="perf.filelist"/>
+  <param name="perf.outputDir" value="${alltest.resultDir}/perf"/>
+  <param name="perf.logFile" value="${alltest.resultDir}/perf/results.xml"/>
+</antcall>
+<antcall target="scan">
+  <param name="scan.outputDir" value="${alltest.resultDir}"/>
+</antcall>
+</target>
 
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.systemId"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/systemId"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/systemId/results.xml"/>
-        </antcall>
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.file"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/file"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/file/results.xml"/>
-        </antcall>
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.dom"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/dom"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/dom/results.xml"/>
-        </antcall>
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.sax"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/sax"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/sax/results.xml"/>
-        </antcall>
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.localPath"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/localPath"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/localPath/results.xml"/>
-        </antcall>
-        <antcall target="contrib">
-            <param name="contrib.flavor" value="trax.stream"/>
-            <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/stream"/>
-            <param name="contrib.logFile" value="${alltest.contrib.resultDir}/stream/results.xml"/>
-        </antcall>
-    </target>
+<target name="alltest.contrib">
+  <property name="alltest.resultDir" value="results-alltest" />
+  <property name="alltest.contrib.resultDir" value="${alltest.resultDir}/contrib" />
+  <echo message="About to execute contrib tests with all flavors, results into ${alltest.contrib.resultDir}/..." />
 
-    <target name="alltest.conf">
-        <property name="alltest.resultDir" value="results-alltest" />
-        <property name="alltest.conf.resultDir" value="${alltest.resultDir}/conf" />
-        <echo message="About to execute conf tests with all flavors, results into ${alltest.conf.resultDir}/..." />
-        <!-- Run full conf test with each major available flavor into 
-             specific output directories; note any user options will 
-             override for all test calls.
-             Also exclude the currently failing tests in the 
-             smoketest if use.excludes is set.
-        -->
-        <condition property="conf.excludes" value="${smoketest.conf.excludes}">
-            <equals arg1="${use.excludes}" arg2="true" />
-        </condition>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.systemId"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/systemId"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/systemId/results.xml"/>
-        </antcall>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.file"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/file"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/file/results.xml"/>
-        </antcall>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.dom"/>
-            <!-- Note DOM always has additional exclusions in conf tests-->
-            <param name="conf.excludes" value="${trax.dom.excludes};${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/dom"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/dom/results.xml"/>
-        </antcall>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.sax"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/sax"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/sax/results.xml"/>
-        </antcall>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.localPath"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/localPath"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/localPath/results.xml"/>
-        </antcall>
-        <antcall target="conf">
-            <param name="conf.flavor" value="trax.stream"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/stream"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/stream/results.xml"/>
-        </antcall>
-        <!-- we should really run conferr with each flavor -->
-        <antcall target="conferr">
-            <param name="conferr.flavor" value="trax.systemId"/>
-            <param name="conferr.outputDir" value="${alltest.conf.resultDir}/conferr"/>
-            <param name="conferr.logFile" value="${alltest.conf.resultDir}/conferr/results.xml"/>
-            <!-- Note that conferr doesn't currently use gold files, 
-                 but we need to set the goldDir anyway for convenience
-            --> 
-            <param name="conferr.goldDir" value="${alltest.conf.resultDir}/conferr-gold"/>
-        </antcall>
-        <!-- To be updated: also use at least one run of ErrorHandlerTestlet -->
-        <antcall target="conf">
-            <param name="conf.testlet" value="org.apache.qetest.xsl.ErrorHandlerTestlet"/>
-            <param name="conf.flavor" value="trax.stream"/>
-            <param name="conf.excludes" value="${conf.excludes}"/>
-            <param name="conf.outputDir" value="${alltest.conf.resultDir}/streamEH"/>
-            <param name="conf.logFile" value="${alltest.conf.resultDir}/streamEH/results.xml"/>
-        </antcall>
-    </target>
+  <antcall target="contrib">
+    <param name="contrib.flavor" value="trax.systemId"/>
+    <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/systemId"/>
+    <param name="contrib.logFile" value="${alltest.contrib.resultDir}/systemId/results.xml"/>
+  </antcall>
+  <antcall target="contrib">
+    <param name="contrib.flavor" value="trax.file"/>
+    <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/file"/>
+    <param name="contrib.logFile" value="${alltest.contrib.resultDir}/file/results.xml"/>
+  </antcall>
+  <antcall target="contrib">
+    <param name="contrib.flavor" value="trax.dom"/>
+    <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/dom"/>
+    <param name="contrib.logFile" value="${alltest.contrib.resultDir}/dom/results.xml"/>
+  </antcall>
+  <antcall target="contrib">
+    <param name="contrib.flavor" value="trax.sax"/>
+    <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/sax"/>
+    <param name="contrib.logFile" value="${alltest.contrib.resultDir}/sax/results.xml"/>
+</antcall>
+<antcall target="contrib">
+  <param name="contrib.flavor" value="trax.localPath"/>
+  <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/localPath"/>
+  <param name="contrib.logFile" value="${alltest.contrib.resultDir}/localPath/results.xml"/>
+</antcall>
+<antcall target="contrib">
+  <param name="contrib.flavor" value="trax.stream"/>
+  <param name="contrib.outputDir" value="${alltest.contrib.resultDir}/stream"/>
+  <param name="contrib.logFile" value="${alltest.contrib.resultDir}/stream/results.xml"/>
+</antcall>
+</target>
 
-    <target name="alltest.accept">
-        <property name="alltest.resultDir" value="results-alltest" />
-        <property name="alltest.accept.resultDir" value="${alltest.resultDir}/accept" />
-        <echo message="About to execute accept tests with all flavors, results into ${alltest.accept.resultDir}/..." />
-        <!-- Run full accept test with each major available flavor into 
-             specific output directories; note any user options will 
-             override for all test calls.
-             Also exclude the currently failing tests in the 
-             smoketest if use.excludes is set.
-        -->
-        <condition property="accept.excludes" value="${smoketest.accept.excludes}">
-            <equals arg1="${use.excludes}" arg2="true" />
-        </condition>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.systemId"/>
-            <param name="accept.excludes" value="${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/systemId"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/systemId/results.xml"/>
-        </antcall>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.file"/>
-            <param name="accept.excludes" value="${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/file"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/file/results.xml"/>
-        </antcall>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.dom"/>
-            <!-- Note DOM always has additional exclusions in accept tests-->
-            <param name="accept.excludes" value="${trax.dom.excludes};${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/dom"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/dom/results.xml"/>
-        </antcall>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.sax"/>
-            <param name="accept.excludes" value="${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/sax"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/sax/results.xml"/>
-        </antcall>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.localPath"/>
-            <param name="accept.excludes" value="${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/localPath"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/localPath/results.xml"/>
-        </antcall>
-        <antcall target="accept">
-            <param name="accept.flavor" value="trax.stream"/>
-            <param name="accept.excludes" value="${accept.excludes}"/>
-            <param name="accept.outputDir" value="${alltest.accept.resultDir}/stream"/>
-            <param name="accept.logFile" value="${alltest.accept.resultDir}/stream/results.xml"/>
-        </antcall>
-        <!-- we should really run accept with each flavor -->
-    </target>
+<target name="alltest.conf">
+  <property name="alltest.resultDir" value="results-alltest" />
+  <property name="alltest.conf.resultDir" value="${alltest.resultDir}/conf" />
+  <echo message="About to execute conf tests with all flavors, results into ${alltest.conf.resultDir}/..." />
+  <!-- Run full conf test with each major available flavor into 
+       specific output directories; note any user options will 
+       override for all test calls.
+       Also exclude the currently failing tests in the 
+       smoketest if use.excludes is set.
+  -->
+  <condition property="conf.excludes" value="${smoketest.conf.excludes}">
+    <equals arg1="${use.excludes}" arg2="true" />
+  </condition>
+  <antcall target="conf">
+    <param name="conf.flavor" value="trax.systemId"/>
+    <param name="conf.excludes" value="${conf.excludes}"/>
+    <param name="conf.outputDir" value="${alltest.conf.resultDir}/systemId"/>
+    <param name="conf.logFile" value="${alltest.conf.resultDir}/systemId/results.xml"/>
+  </antcall>
+  <antcall target="conf">
+    <param name="conf.flavor" value="trax.file"/>
+    <param name="conf.excludes" value="${conf.excludes}"/>
+    <param name="conf.outputDir" value="${alltest.conf.resultDir}/file"/>
+    <param name="conf.logFile" value="${alltest.conf.resultDir}/file/results.xml"/>
+  </antcall>
+  <antcall target="conf">
+    <param name="conf.flavor" value="trax.dom"/>
+    <!-- Note DOM always has additional exclusions in conf tests-->
+    <param name="conf.excludes" value="${trax.dom.excludes};${conf.excludes}"/>
+    <param name="conf.outputDir" value="${alltest.conf.resultDir}/dom"/>
+    <param name="conf.logFile" value="${alltest.conf.resultDir}/dom/results.xml"/>
+  </antcall>
+  <antcall target="conf">
+    <param name="conf.flavor" value="trax.sax"/>
+    <param name="conf.excludes" value="${conf.excludes}"/>
+    <param name="conf.outputDir" value="${alltest.conf.resultDir}/sax"/>
+    <param name="conf.logFile" value="${alltest.conf.resultDir}/sax/results.xml"/>
+</antcall>
+<antcall target="conf">
+  <param name="conf.flavor" value="trax.localPath"/>
+  <param name="conf.excludes" value="${conf.excludes}"/>
+  <param name="conf.outputDir" value="${alltest.conf.resultDir}/localPath"/>
+  <param name="conf.logFile" value="${alltest.conf.resultDir}/localPath/results.xml"/>
+</antcall>
+<antcall target="conf">
+  <param name="conf.flavor" value="trax.stream"/>
+  <param name="conf.excludes" value="${conf.excludes}"/>
+  <param name="conf.outputDir" value="${alltest.conf.resultDir}/stream"/>
+  <param name="conf.logFile" value="${alltest.conf.resultDir}/stream/results.xml"/>
+</antcall>
+<!-- we should really run conferr with each flavor -->
+<antcall target="conferr">
+  <param name="conferr.flavor" value="trax.systemId"/>
+  <param name="conferr.outputDir" value="${alltest.conf.resultDir}/conferr"/>
+  <param name="conferr.logFile" value="${alltest.conf.resultDir}/conferr/results.xml"/>
+  <!-- Note that conferr doesn't currently use gold files, 
+       but we need to set the goldDir anyway for convenience
+  --> 
+  <param name="conferr.goldDir" value="${alltest.conf.resultDir}/conferr-gold"/>
+</antcall>
+<!-- To be updated: also use at least one run of ErrorHandlerTestlet -->
+<antcall target="conf">
+  <param name="conf.testlet" value="org.apache.qetest.xsl.ErrorHandlerTestlet"/>
+  <param name="conf.flavor" value="trax.stream"/>
+  <param name="conf.excludes" value="${conf.excludes}"/>
+  <param name="conf.outputDir" value="${alltest.conf.resultDir}/streamEH"/>
+  <param name="conf.logFile" value="${alltest.conf.resultDir}/streamEH/results.xml"/>
+</antcall>
+</target>
 
-    <target name="alltest.conf.xsltc">
-        <property name="alltest.xsltc.resultDir" value="results-alltest.xsltc" />
-        <property name="alltest.conf.xsltc.resultDir" value="${alltest.xsltc.resultDir}/conf" />
-        <echo message="About to execute xsltc.conf tests with all flavors, results into ${alltest.conf.xsltc.resultDir}/..." />
-        <!-- Run full conf test with each major available flavor into 
-             specific output directories; note any user options will 
-             override for all test calls.
-             Also exclude the currently failing tests in the 
-             smoketest if use.excludes is set.
-        -->
-        <condition property="conf.xsltc.excludes" value="${smoketest.conf.xsltc.excludes}">
-            <equals arg1="${use.excludes}" arg2="true" />
-        </condition>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.systemId"/>
-            <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/systemId"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/systemId/results.xml"/>
-        </antcall>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.file"/>
-            <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/file"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/file/results.xml"/>
-        </antcall>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.dom"/>
-            <!-- Note DOM always has additional exclusions in conf tests-->
-            <param name="conf.xsltc.excludes" value="${trax.dom.excludes};${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/dom"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/dom/results.xml"/>
-        </antcall>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.sax"/>
-            <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/sax"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/sax/results.xml"/>
-        </antcall>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.localPath"/>
-            <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/localPath"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/localPath/results.xml"/>
-        </antcall>
-        <antcall target="conf.xsltc">
-            <param name="conf.xsltc.flavor" value="trax.stream"/>
-            <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
-            <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/stream"/>
-            <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/stream/results.xml"/>
-        </antcall>
-    </target>
+<target name="alltest.accept">
+  <property name="alltest.resultDir" value="results-alltest" />
+  <property name="alltest.accept.resultDir" value="${alltest.resultDir}/accept" />
+  <echo message="About to execute accept tests with all flavors, results into ${alltest.accept.resultDir}/..." />
+  <!-- Run full accept test with each major available flavor into 
+       specific output directories; note any user options will 
+       override for all test calls.
+       Also exclude the currently failing tests in the 
+       smoketest if use.excludes is set.
+  -->
+  <condition property="accept.excludes" value="${smoketest.accept.excludes}">
+    <equals arg1="${use.excludes}" arg2="true" />
+</condition>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.systemId"/>
+  <param name="accept.excludes" value="${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/systemId"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/systemId/results.xml"/>
+</antcall>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.file"/>
+  <param name="accept.excludes" value="${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/file"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/file/results.xml"/>
+</antcall>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.dom"/>
+  <!-- Note DOM always has additional exclusions in accept tests-->
+  <param name="accept.excludes" value="${trax.dom.excludes};${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/dom"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/dom/results.xml"/>
+</antcall>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.sax"/>
+  <param name="accept.excludes" value="${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/sax"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/sax/results.xml"/>
+</antcall>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.localPath"/>
+  <param name="accept.excludes" value="${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/localPath"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/localPath/results.xml"/>
+</antcall>
+<antcall target="accept">
+  <param name="accept.flavor" value="trax.stream"/>
+  <param name="accept.excludes" value="${accept.excludes}"/>
+  <param name="accept.outputDir" value="${alltest.accept.resultDir}/stream"/>
+  <param name="accept.logFile" value="${alltest.accept.resultDir}/stream/results.xml"/>
+</antcall>
+<!-- we should really run accept with each flavor -->
+</target>
 
-    <target name="alltest.accept.xsltc">
-        <property name="alltest.xsltc.resultDir" value="results-alltest.xsltc" />
-        <property name="alltest.accept.xsltc.resultDir" value="${alltest.xsltc.resultDir}/accept" />
-        <echo message="About to execute xsltc.accept tests with all flavors, results into ${alltest.accept.xsltc.resultDir}/..." />
-        <!-- Run full accept test with each major available flavor into 
-             specific output directories; note any user options will 
-             override for all test calls.
-             Also exclude the currently failing tests in the 
-             smoketest if use.excludes is set.
-        -->
-        <condition property="accept.xsltc.excludes" value="${smoketest.accept.xsltc.excludes}">
-            <equals arg1="${use.excludes}" arg2="true" />
-        </condition>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.systemId"/>
-            <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/systemId"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/systemId/results.xml"/>
-        </antcall>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.file"/>
-            <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/file"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/file/results.xml"/>
-        </antcall>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.dom"/>
-            <!-- Note DOM always has additional exclusions in accept tests-->
-            <param name="accept.xsltc.excludes" value="${trax.dom.excludes};${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/dom"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/dom/results.xml"/>
-        </antcall>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.sax"/>
-            <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/sax"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/sax/results.xml"/>
-        </antcall>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.localPath"/>
-            <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/localPath"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/localPath/results.xml"/>
-        </antcall>
-        <antcall target="accept.xsltc">
-            <param name="accept.xsltc.flavor" value="trax.stream"/>
-            <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
-            <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/stream"/>
-            <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/stream/results.xml"/>
-        </antcall>
-    </target>
+<target name="alltest.conf.xsltc">
+  <property name="alltest.xsltc.resultDir" value="results-alltest.xsltc" />
+  <property name="alltest.conf.xsltc.resultDir" value="${alltest.xsltc.resultDir}/conf" />
+  <echo message="About to execute xsltc.conf tests with all flavors, results into ${alltest.conf.xsltc.resultDir}/..." />
+  <!-- Run full conf test with each major available flavor into 
+       specific output directories; note any user options will 
+       override for all test calls.
+       Also exclude the currently failing tests in the 
+       smoketest if use.excludes is set.
+  -->
+  <condition property="conf.xsltc.excludes" value="${smoketest.conf.xsltc.excludes}">
+    <equals arg1="${use.excludes}" arg2="true" />
+  </condition>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.systemId"/>
+    <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/systemId"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/systemId/results.xml"/>
+  </antcall>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.file"/>
+    <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/file"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/file/results.xml"/>
+  </antcall>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.dom"/>
+    <!-- Note DOM always has additional exclusions in conf tests-->
+    <param name="conf.xsltc.excludes" value="${trax.dom.excludes};${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/dom"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/dom/results.xml"/>
+  </antcall>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.sax"/>
+    <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/sax"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/sax/results.xml"/>
+  </antcall>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.localPath"/>
+    <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/localPath"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/localPath/results.xml"/>
+  </antcall>
+  <antcall target="conf.xsltc">
+    <param name="conf.xsltc.flavor" value="trax.stream"/>
+    <param name="conf.xsltc.excludes" value="${conf.xsltc.excludes}"/>
+    <param name="conf.xsltc.outputDir" value="${alltest.conf.xsltc.resultDir}/stream"/>
+    <param name="conf.xsltc.logFile" value="${alltest.conf.xsltc.resultDir}/stream/results.xml"/>
+  </antcall>
+</target>
 
-    <target name="alltest.conf.trace">
-        <property name="conf.trace" value="on"/>
-        <antcall target="alltest.conf"/>
-    </target>
+<target name="alltest.accept.xsltc">
+  <property name="alltest.xsltc.resultDir" value="results-alltest.xsltc" />
+  <property name="alltest.accept.xsltc.resultDir" value="${alltest.xsltc.resultDir}/accept" />
+  <echo message="About to execute xsltc.accept tests with all flavors, results into ${alltest.accept.xsltc.resultDir}/..." />
+  <!-- Run full accept test with each major available flavor into 
+       specific output directories; note any user options will 
+       override for all test calls.
+       Also exclude the currently failing tests in the 
+       smoketest if use.excludes is set.
+  -->
+  <condition property="accept.xsltc.excludes" value="${smoketest.accept.xsltc.excludes}">
+    <equals arg1="${use.excludes}" arg2="true" />
+</condition>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.systemId"/>
+  <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/systemId"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/systemId/results.xml"/>
+</antcall>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.file"/>
+  <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/file"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/file/results.xml"/>
+</antcall>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.dom"/>
+  <!-- Note DOM always has additional exclusions in accept tests-->
+  <param name="accept.xsltc.excludes" value="${trax.dom.excludes};${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/dom"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/dom/results.xml"/>
+</antcall>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.sax"/>
+  <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/sax"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/sax/results.xml"/>
+</antcall>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.localPath"/>
+  <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/localPath"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/localPath/results.xml"/>
+</antcall>
+<antcall target="accept.xsltc">
+  <param name="accept.xsltc.flavor" value="trax.stream"/>
+  <param name="accept.xsltc.excludes" value="${accept.xsltc.excludes}"/>
+  <param name="accept.xsltc.outputDir" value="${alltest.accept.xsltc.resultDir}/stream"/>
+  <param name="accept.xsltc.logFile" value="${alltest.accept.xsltc.resultDir}/stream/results.xml"/>
+</antcall>
+</target>
 
-    <target name="alltest.accept.trace">
-        <property name="accept.trace" value="on"/>
-        <antcall target="alltest.accept"/>
-    </target>
+<target name="alltest.conf.trace">
+  <property name="conf.trace" value="on"/>
+  <antcall target="alltest.conf"/>
+</target>
 
-    <target name="test"
+<target name="alltest.accept.trace">
+  <property name="accept.trace" value="on"/>
+  <antcall target="alltest.accept"/>
+</target>
+
+<target name="test"
         depends="alltest"
         description="Alias for alltest">
-    </target>
+</target>
 
-    <target name="check"
+<target name="check"
         depends="alltest"
         description="Alias for alltest">
-    </target>
+</target>
 
-    <!-- ResultScanner was failing when run against the Maven build,
-         apparently due to conflicting TransformerFactory
-         defaults. The simplest solution is to make clear that we want to use
-	 our version of Apache Xalan, by setting the Boot Class Path. 	
-    -->
-    <target name="scan"
+<!-- ResultScanner was failing when run against the Maven build,
+     apparently due to conflicting TransformerFactory
+     defaults. The simplest solution is to make clear that we want to use
+     our version of Apache Xalan, by setting the Boot Class Path.       
+-->
+<target name="scan"
         description="Run a simple ResultScanner on a tree of test results">
-        <property name="scan.outputDir" value="results-alltest" />
-        <property name="scan.logFile" value="${scan.outputDir}/ResultReport" />
-        <java classname="org.apache.qetest.xsl.ResultScanner" 
-              classpathref="conf.class.path" 
-              fork="yes" >
-	    <bootclasspath>
-	        <path refid="boot.class.path"/>
-	    </bootclasspath>
-            <arg line="${scan.outputDir} ${scan.logFile}"/>
-        </java>	 
-    </target>
+  <property name="scan.outputDir" value="results-alltest" />
+  <property name="scan.logFile" value="${scan.outputDir}/ResultReport" />
+  <java classname="org.apache.qetest.xsl.ResultScanner" 
+        classpathref="conf.class.path" 
+        fork="yes" >
+    <jvmarg line="${JAXP.set.Transformer}"/>
+    <jvmarg line="${JAXP.set.DocumentBuilder}"/>
+    <jvmarg line="${JAXP.set.SAXParser}"/>
+    <!-- <bootclasspath> -->
+    <!--   <path refid="boot.class.path"/> -->
+    <!-- </bootclasspath> -->
+    <arg line="${scan.outputDir} ${scan.logFile}"/>
+</java>  
+</target>
 
-    <!-- ================================================================== -->
-    <!-- Build Tests: Compile/jar targets for each 'layer' of testing code  -->
-    <!-- ================================================================== -->
-    <target name="compile.qetest" depends="init.build"
+<!-- ================================================================== -->
+<!-- Build Tests: Compile/jar targets for each 'layer' of testing code  -->
+<!-- ================================================================== -->
+<target name="compile.qetest" depends="init.build"
         description="Compile base qetest files; no Xalan dependencies">
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}*.java"
-               debug="${debug}" nowarn="${compiler.nowarn}"/>
-    </target>
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}*.java"
+         debug="${debug}" nowarn="${compiler.nowarn}"/>
+</target>
 
 
-    <target name="jar.qetest" depends="compile.qetest"
+<target name="jar.qetest" depends="compile.qetest"
         description="Jar base qetest files; no Xalan dependencies">
-        <jar jarfile="${qetest.jar}" 
-             basedir="${test.build.dir}" 
-             includes="${test.root}*.java,${test.root}*.properties"/>
-    </target>
+  <jar jarfile="${qetest.jar}" 
+       basedir="${test.build.dir}" 
+       includes="${test.root}*.java,${test.root}*.properties"/>
+</target>
 
 
-    <!-- This step should be dependent upon general XML/XSL 
-         functionality like SAX, DOM, JAXP and the like, but 
-         should not directly depend on Xalan 
-   -->
-    <target name="compile.xsl" depends="compile.qetest"
+<!-- This step should be dependent upon general XML/XSL 
+     functionality like SAX, DOM, JAXP and the like, but 
+     should not directly depend on Xalan 
+-->
+<target name="compile.xsl" depends="compile.qetest"
         description="Compile TransformWrapper and associated classes">
-        <!-- This javac has no dependencies -->
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}xslwrapper/TransformWrapperHelper.java,${test.root}xslwrapper/TransformWrapper.java,${test.root}xslwrapper/TransformWrapperFactory.java"
-               debug="${debug}" nowarn="${compiler.nowarn}"/>
-        <!-- This javac depends on JAXP, SAX, DOM; hence the specific classpathref -->
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}xsl/*.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+  <!-- This javac has no dependencies -->
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}xslwrapper/TransformWrapperHelper.java,${test.root}xslwrapper/TransformWrapper.java,${test.root}xslwrapper/TransformWrapperFactory.java"
+         debug="${debug}" nowarn="${compiler.nowarn}"/>
+  <!-- This javac depends on JAXP, SAX, DOM; hence the specific classpathref -->
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}xsl/*.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="compile.trax.xslwrappers" depends="compile.xsl"
+<target name="compile.trax.xslwrappers" depends="compile.xsl"
         description="Compile Trax*Wrapper xslwrappers only">
-        <!-- Should only be dependent on JAXP, not Xalan specifically -->
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}xslwrapper/Trax*Wrapper.java,${test.root}xslwrapper/TraxWrapperUtils.java,${test.root}xslwrapper/XalanProcessWrapper.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+  <!-- Should only be dependent on JAXP, not Xalan specifically -->
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}xslwrapper/Trax*Wrapper.java,${test.root}xslwrapper/TraxWrapperUtils.java,${test.root}xslwrapper/XalanProcessWrapper.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="compile.trax" depends="compile.xsl,compile.trax.xslwrappers"
+<target name="compile.trax" depends="compile.xsl,compile.trax.xslwrappers"
         description="Compile various JAXP-based API tests">
-        <!-- Should only be dependent on JAXP, not Xalan specifically -->
-        <!-- Separate javac steps to avoid compiler oddities -->
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}trax/*.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}trax/stream/*.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}trax/dom/*.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}trax/sax/*.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+  <!-- Should only be dependent on JAXP, not Xalan specifically -->
+  <!-- Separate javac steps to avoid compiler oddities -->
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}trax/*.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}trax/stream/*.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}trax/dom/*.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}trax/sax/*.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="compile" depends="compile.trax">
-        <echo message="Compile Xalan-J 2.x specific tests" />
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}xalanj2/*.java,${test.root}dtm/*.java"
-               excludes="${test.root}dtm/xsltcDocCode.java"
-               debug="${debug}"
-               classpathref="compiletest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+<target name="compile" depends="compile.trax">
+  <echo message="Compile Xalan-J 2.x specific tests" />
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}xalanj2/*.java,${test.root}dtm/*.java"
+         excludes="${test.root}dtm/xsltcDocCode.java"
+         debug="${debug}"
+         classpathref="compiletest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="compile.rwapi" depends="compile">
-        <echo message="Compile xslt20 / XPath2.0 RWAPI tests" />
-        <javac srcdir="${test.src.dir}" 
-               destdir="${test.build.dir}" 
-               includes="${test.root}rwapi/*.*"
-               debug="${debug}"
-               classpathref="rwapitest.class.path" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+<target name="compile.rwapi" depends="compile">
+  <echo message="Compile xslt20 / XPath2.0 RWAPI tests" />
+  <javac srcdir="${test.src.dir}" 
+         destdir="${test.build.dir}" 
+         includes="${test.root}rwapi/*.*"
+         debug="${debug}"
+         classpathref="rwapitest.class.path" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <!-- Note that this target must *not* depend on any XSLTC tests, 
-         which have to be compiled separately; otherwise the 
-         smoketest will fail.
-    -->
-    <target name="jar" depends="compile"
+<!-- Note that this target must *not* depend on any XSLTC tests, 
+     which have to be compiled separately; otherwise the 
+     smoketest will fail.
+-->
+<target name="jar" depends="compile"
         description="Build testxsl.jar with all available tests">
-        <jar jarfile="${testxsl.jar}" 
-             basedir="${test.build.dir}" 
-             includes="**/*.class,**/*.properties" />
-    </target>
+  <jar jarfile="${testxsl.jar}" 
+       basedir="${test.build.dir}" 
+       includes="**/*.class,**/*.properties" />
+</target>
 
-    <!-- ... what's our exclude syntax? -->
-    <target name="bugzilla.classes" depends="jar"
+<!-- ... what's our exclude syntax? -->
+<target name="bugzilla.classes" depends="jar"
         description="Compile any bugzilla testlet classes">
-        <mkdir dir="${tests.bugzilla.build.dir}" />
-        <javac srcdir="${tests.bugzilla.dir}" 
-               destdir="${tests.bugzilla.build.dir}" 
-               debug="${debug}"
-               excludes="Bugzilla1288.java"
-               classpath="${xalan.jar}:${testxsl.jar}" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+  <mkdir dir="${tests.bugzilla.build.dir}" />
+  <javac srcdir="${tests.bugzilla.dir}" 
+         destdir="${tests.bugzilla.build.dir}" 
+         debug="${debug}"
+         excludes="Bugzilla1288.java"
+         classpath="${xalan.jar}:${testxsl.jar}" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="jira.classes" depends="jar"
+<target name="jira.classes" depends="jar"
         description="Compile any jira testlet classes">
-        <mkdir dir="${tests.jira.build.dir}" />
-        <javac srcdir="${tests.jira.dir}" 
-               destdir="${tests.jira.build.dir}" 
-               debug="${debug}"
-               classpath="${xalan.jar}:${testxsl.jar}" 
-               nowarn="${compiler.nowarn}"/>
-    </target>
+  <mkdir dir="${tests.jira.build.dir}" />
+  <javac srcdir="${tests.jira.dir}" 
+         destdir="${tests.jira.build.dir}" 
+         debug="${debug}"
+         classpath="${xalan.jar}:${testxsl.jar}" 
+         nowarn="${compiler.nowarn}"/>
+</target>
 
-    <target name="extensions.classes" depends="jar"
+<target name="extensions.classes" depends="jar"
         description="Compile any extensions test classes">
-        <mkdir dir="${tests.extensions.build.dir}" />
-        <javac srcdir="${tests.extensions.dir}" 
-               destdir="${tests.extensions.build.dir}" 
-               debug="${debug}"
-               classpathref="extensions.class.path" 
-               nowarn="${compiler.nowarn}"/>
-        <!-- Add more javac calls if we add more Java extensions dirs -->        
-    </target>
+  <mkdir dir="${tests.extensions.build.dir}" />
+  <javac srcdir="${tests.extensions.dir}" 
+         destdir="${tests.extensions.build.dir}" 
+         debug="${debug}"
+         classpathref="extensions.class.path" 
+         nowarn="${compiler.nowarn}"/>
+  <!-- Add more javac calls if we add more Java extensions dirs -->        
+</target>
 
-    <!-- This target compiles both the main tests and test drivers 
-         in testxsl.jar from the java/ directory, as well as 
-         various other classes in subdirs under tests/
-    -->
-    <target name="all" description="Build testxsl.jar *and* compile .java under tests/"
+<!-- This target compiles both the main tests and test drivers 
+     in testxsl.jar from the java/ directory, as well as 
+     various other classes in subdirs under tests/
+-->
+<target name="all" description="Build testxsl.jar *and* compile .java under tests/"
         depends="jar,bugzilla.classes,jira.classes,extensions.classes">
-    </target>
+</target>
 
-    <target name="main"
+<target name="main"
         depends="all"
         description="Alias for all">
-    </target>
+</target>
 
-    <!-- =================================================================== -->
-    <!-- Various targets to clean the build tree                             -->
-    <!-- =================================================================== -->
-    <target name="distclean" depends="clean"
+<!-- =================================================================== -->
+<!-- Various targets to clean the build tree                             -->
+<!-- =================================================================== -->
+<target name="distclean" depends="clean"
         description="Clean everything, including most test results!" >
-        <delete dir="${alltest.resultDir}" />
-        <delete dir="${api.outputDir}" />
-        <delete dir="${conf.outputDir}" />
-        <delete dir="${perf.outputDir}" />
-        <delete dir="${contrib.outputDir}" />
-        <delete dir="${smoketest.outputDir}" />
-    </target>
+  <delete dir="${alltest.resultDir}" />
+  <delete dir="${api.outputDir}" />
+  <delete dir="${conf.outputDir}" />
+  <delete dir="${perf.outputDir}" />
+  <delete dir="${contrib.outputDir}" />
+  <delete dir="${smoketest.outputDir}" />
+</target>
 
-    <target name="clean"
+<target name="clean"
         description="Clean up the compiled tests and docs">
-        <delete dir="${test.build.dir}"/>
-        <delete dir="${tests.bugzilla.build.dir}"/>
-        <delete dir="${tests.jira.build.dir}"/>
-        <delete dir="${tests.extensions.build.dir}"/>
-        <delete dir="${xdocs.style}"/> <!-- init.build.docs creates this tree -->
-    </target>
+  <delete dir="${test.build.dir}"/>
+  <delete dir="${tests.bugzilla.build.dir}"/>
+  <delete dir="${tests.jira.build.dir}"/>
+  <delete dir="${tests.extensions.build.dir}"/>
+  <delete dir="${xdocs.style}"/> <!-- init.build.docs creates this tree -->
+</target>
 
 
-    <!-- ================================================================== -->
-    <!-- Build docs: Creates the User's Guide                               -->
+<!-- ================================================================== -->
+<!-- Build docs: Creates the User's Guide                               -->
     <!-- ================================================================== -->
     <target name="docs" depends="init.docs"
         description="Build the framework/overview docs for tests">
         <java fork="yes" 
             classname="${doc.generator}" 
             classpathref="test.docs.class.path" >
+            <jvmarg line="{$JAXP.set.Transformer}"/>
+            <jvmarg line="{$JAXP.set.DocumentBuilder}"/>
+            <jvmarg line="{$JAXP.set.SAXParser}"/>
             <arg line="targetDirectory=${test.build.docs} ${test.xdocs.book} ${test.xdocs.style}"/>
-        </java>	 
+        </java>  
     </target>
 
     <!-- ================================================================== -->
@@ -1690,35 +1735,28 @@ dependencies - users must manually 'build jar' first.
     <!-- ================================================================== -->
     <!-- Special: Targets specific to XSLTC which requires extra .jars      -->
     <!-- This section will be updated as xsltc integrates more with xalan   -->
+    <!-- TODO REVIEW: Time to drop these?                                   -->
     <!-- ================================================================== -->
-    <!-- Actually, I'd like to figure out some sneaky Ant trick to 
-         allow swapping of parts of classpaths (i.e. swap in xsltc.jar 
-         and related files instead of xalan.jar; likewise replace 
-         xercesImpl.jar with the PARSER_JAR defined outside) to clean 
-         this section up.  But for the time being I'm planning on 
-         simply maintaining separate-but-equal targets.xsltc
-    -->
-
     <path id="xsltc.runtime.class.path">
         <pathelement location="${xalan.build.dir}/xalan.jar" />
-        
-        <!-- add xsltc.jar so we can test the separate jar distribution -->
-        <pathelement location="${xalan.build.dir}/xsltc.jar" />
+        <!-- separate xsltc.jar is no longer produced -->
+        <!-- <pathelement location="${xsltc.jar}" /> -->
         <pathelement location="${ser.jar}" />
-         
         <pathelement location="${testxsl.jar}" />
+        <pathelement location="${endorsed.parserjar}" />
         <pathelement location="${parserjar}" />
+        <pathelement location="${endorsed.xml-apis.jar}" />
         <pathelement location="${xml-apis.jar}" />
         <pathelement location="${jtidy.jar}" />
     </path>
     <path id="xsltc.compile.class.path">
         <pathelement location="${xalan.build.dir}/xalan.jar" />
-        
-        <!-- add xsltc.jar so we can test the separate jar distribution -->
-        <pathelement location="${xalan.build.dir}/xsltc.jar" />
-        
+        <!-- separate xsltc.jar is no longer produced -->
+        <!-- <pathelement location="${xsltc.jar}" /> -->
         <pathelement location="${testxsl.jar}" />
+        <pathelement location="${endorsed.parserjar}" />
         <pathelement location="${parserjar}" />
+        <pathelement location="${endorsed.xml-apis.jar}" />
         <pathelement location="${xml-apis.jar}" />
         <pathelement location="${jtidy.jar}" />
         <!-- Note addition of . to the classpath to enable loading 
@@ -1734,8 +1772,8 @@ dependencies - users must manually 'build jar' first.
         <echo message="Executing Xalan-xsltc conf test: ${testClass}" />
         <!-- Special: allow explicit test.properties overrides for inputDir, etc for xsltc -->
         <property name="testType" value="conf.xsltc." />
-	    <!-- Set indent-number to 0 to match Xalan's default indentation -->
-	    <property name="${testType}Processor.setAttribute.indent-number" value="0"/>
+            <!-- Set indent-number to 0 to match Xalan's default indentation -->
+            <property name="${testType}Processor.setAttribute.indent-number" value="0"/>
         <antcall target="run.xalantest">
             <param name="xalantest.classpathref"
                    value="xsltc.runtime.class.path" />
@@ -1750,7 +1788,8 @@ dependencies - users must manually 'build jar' first.
         
         <xsltcTestsTask inputDir="tests/xsltc/attribset" 
                         resultDir="results-xsltc-compile-verification-tests" 
-                        bootclasspathref="boot.class.path"/>
+                        />
+                        <!-- bootclasspathref="boot.class.path" -->
 
         <echo message=""/>
         <echo message=" [minitest] Completed, running the 'xsltc compilation error verification' tests, and these have passed" />
@@ -1782,7 +1821,7 @@ dependencies - users must manually 'build jar' first.
 
 
     <target name="perf.saxon" description="Run TestletDriver over the perf tree using Saxon">
-		<!-- New addition,  NOT TESTED -->
+                <!-- New addition,  NOT TESTED -->
         <!-- Set the default conformance test driver, user may override -->
         <property name="testClass" value="org.apache.qetest.xsl.StylesheetTestletDriver" />
         <echo message="Executing Saxon perf test: ${testClass}" />

--- a/java/src/org/apache/qetest/xsl/XHTComparator.java
+++ b/java/src/org/apache/qetest/xsl/XHTComparator.java
@@ -260,7 +260,7 @@ public class XHTComparator
 
         String value1 = gold.getNodeValue();
         String value2 = test.getNodeValue();
-
+	
         if ((null != value1) && (null != value2) &&!value1.equals(value2))
         {
             reporter.println(MISMATCH_VALUE + nodeTypeString(gold) + "len="

--- a/java/src/org/apache/qetest/xsl/XHTComparator.java
+++ b/java/src/org/apache/qetest/xsl/XHTComparator.java
@@ -260,7 +260,7 @@ public class XHTComparator
 
         String value1 = gold.getNodeValue();
         String value2 = test.getNodeValue();
-	
+
         if ((null != value1) && (null != value2) &&!value1.equals(value2))
         {
             reporter.println(MISMATCH_VALUE + nodeTypeString(gold) + "len="


### PR DESCRIPTION
Major motivation: Change paths to tolerate both the existing ant build and the new mvn build that will soon replace it. (Filenames and locations of dependencies are not identical.) That will permit actually cutting over to mvn.

DEFERRED: In the process: Eliminate the old bootclasspath and java.endorsed.dirs workarounds, which were needed before the combined introduction of JAXP/TrAX/javax and the JRE's moving its copy of Apache code into com.sun.org.apache.local. We do need to add properties/parameters so the JRE's factories will find our implementation rather than those shadows.

And I've commented out some old code that hadn't been relevant since xsltc had been absorbed into Xalan.

NOTE: Before reporting problems, compare behavior with the unmodified version. Some of our targets fell out of use; others test and report known errors but do consider them regressions.

NOTE: Some indentation may have changed; I recommend diffing with whitespace ignored (-b). I've tried to avoid tabs.