### PR TITLE
Make sure the new stream tests gate apitest success or failure

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -701,17 +701,20 @@ dependencies - users must manually 'build jar' first.
                <available file="results-api/Pass-SAXSourceAPITest.xml" />
                <available file="results-api/Pass-SAXTransformerFactoryAPITest.xml" />
                <available file="results-api/Pass-SerializedStylesheetTest.xml" />
+               <available file="results-api/Pass-StreamResultAPITest.xml" />
                <available file="results-api/Pass-SystemIDResolverAPITest.xml" />
                <available file="results-api/Pass-TemplatesHandlerAPITest.xml" />
                <available file="results-api/Pass-TestDTM.xml" />
                <available file="results-api/Pass-TestDTMIter.xml" />
                <available file="results-api/Pass-TestDTMTrav.xml" />
                <available file="results-api/Pass-TestXPathAPI.xml" />
+               <available file="results-api/Pass-ToHTMLStreamTest.xml" />
+               <available file="results-api/Pass-ToXMLStreamTest.xml" />
                <available file="results-api/Pass-TraceListenerTest.xml" />
+               <available file="results-api/Pass-TransformStateAPITest.xml" />
                <available file="results-api/Pass-TransformerFactoryAPITest.xml" />
                <available file="results-api/Pass-TransformerHandlerAPITest.xml" />
                <available file="results-api/Pass-TransformerHandlerTest.xml" />
-               <available file="results-api/Pass-TransformStateAPITest.xml" />
                <available file="results-api/Pass-URIResolverTest.xml" />
             </and>
         </condition>


### PR DESCRIPTION
Notes to myself:

Apparently we're relying on an explicit list of expected-good tests in build.xml, looking for the Pass-testname files.

There is currently one known fail in SmoketestOuttakes (which is why it's an outtake), which I believe is also reflected in Harness failing. Should sanity check that it's something we're aware of and have either accepted divergence on or opened a work item for.

Also note that the performance tests (TimeDTM*) are deliberately considered ambiguous, since we don't have anything calculating "reasonable" time limits for a platform, and indeed that's nontrivial to do. Performance testing is usually conducted manually/locally.