### PR TITLE
Xalanj 2725

### DIFF
--- a/java/src/org/apache/qetest/trax/ToStreamTest.java
+++ b/java/src/org/apache/qetest/trax/ToStreamTest.java
@@ -90,6 +90,20 @@ public abstract class ToStreamTest extends FileBasedTest
 		return writer.getBuffer().toString();
 	}
 
+	protected String outputCharacters(ToStream stream, String input, final int bufLength) throws SAXException {
+		StringWriter writer = new StringWriter();
+		stream.setOmitXMLDeclaration(true);
+		stream.setWriter(writer);
+		char[] chars = new char[bufLength];
+		for(int i = 0; i < input.length(); i+=bufLength) {
+			int length = ( i + bufLength > input.length() ? input.length() - i : bufLength );
+			input.getChars(i, i + length, chars, 0);
+			stream.characters(chars, 0, length);
+		}
+		stream.flushPending();
+		return writer.getBuffer().toString();
+	}
+
 	protected String outputAttrValue(ToStream stream, String input) throws SAXException, IOException {
 		StringWriter writer = new StringWriter();
 		stream.setOmitXMLDeclaration(true);

--- a/java/src/org/apache/qetest/trax/ToXMLStreamTest.java
+++ b/java/src/org/apache/qetest/trax/ToXMLStreamTest.java
@@ -105,7 +105,7 @@ public class ToXMLStreamTest extends ToStreamTest
      */
     public boolean testCase2() throws SAXException, IOException
     {
-    	reporter.testCaseInit("Verify setting output properties individually or whole blocks.");
+    	reporter.testCaseInit("Verify handling of ISO-8859-1 encoding in ToStream");
 
 		String actual1 = outputCharacters(makeStream("ISO-8859-1"), "abc");
 		reporter.check(actual1, "abc", "Simple characters should come out unscathed");
@@ -144,7 +144,7 @@ public class ToXMLStreamTest extends ToStreamTest
      */
     public boolean testCase3() throws SAXException, IOException
     {
-    	reporter.testCaseInit("Verify setting output properties individually or whole blocks.");
+    	reporter.testCaseInit("Verify handling of ASCII encoding in ToStream");
 
     	String actual1 = outputCharacters(makeStream("ASCII"), "abc");
 		reporter.check(actual1, "abc", "Simple characters should come out unscathed");

--- a/java/src/org/apache/qetest/trax/ToXMLStreamTest.java
+++ b/java/src/org/apache/qetest/trax/ToXMLStreamTest.java
@@ -88,6 +88,8 @@ public class ToXMLStreamTest extends ToStreamTest
 		
 		String actual4 = outputCharacters(makeStream("UTF-8"), utf16String);
 		reporter.check(actual4, utf16String, "Astral characters should come out unscathed");
+		String actual4b = outputCharacters(makeStream("UTF-8"), utf16String, utf16String.length() - 1);
+		reporter.check(actual4b, utf16String, "Astral characters should come out unscathed (in split buffer)");
 		String actual4a = outputAttrValue(makeStream("UTF-8"), utf16String);
 		reporter.check(actual4a, utf16String, "Astral characters should come out unscathed (as attribute value)");
 		


### PR DESCRIPTION
New tests for XALANJ-2725, courtesy of @maxfortun.  There is a matching changeset in xalan-java with fixes to resolve this test.